### PR TITLE
restart supervisor after update (#13)

### DIFF
--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -17,3 +17,4 @@ Roles/Recipes from Ansible Galaxy
 
 * miniconda: https://galaxy.ansible.com/andrewrothstein/miniconda/
 * nginx: https://galaxy.ansible.com/jdauphant/nginx/
+* supervisor: https://galaxy.ansible.com/geerlingguy/supervisor

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -83,6 +83,10 @@ Install Ansible roles::
 Run Vagrant
 +++++++++++
 
+Use WPS config for Vagrant VM::
+
+  $ ln -s sample-vagrant.yml custom.yml
+
 Initial setup::
 
   $ vagrant up

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,8 +20,6 @@
       tags:
         miniconda
     - role: geerlingguy.supervisor
-      supervisor_unix_http_server_enable: true
-      supervisor_password: '123'
       tags:
         supervisor
     - role: geerlingguy.nginx

--- a/roles/pywps/handlers/main.yml
+++ b/roles/pywps/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: restart pywps
-  supervisorctl: name={{ wps_name }} state=restarted
+  supervisorctl:
+    name: "{{ wps_name }}"
+    state: restarted
+    username: "{{ supervisor_user }}"
+    password: "{{ supervisor_password }}"

--- a/roles/pywps/tasks/main.yml
+++ b/roles/pywps/tasks/main.yml
@@ -80,8 +80,9 @@
     - pywps
     - conf
 
-# - name: Assure application running at end of playbook
-#   command: /bin/true
-#   notify: restart pywps
-#   tags:
-#     conf
+- name: Assure application running at end of playbook
+  command: /bin/true
+  notify: restart pywps
+  tags:
+    - pywps
+    - conf


### PR DESCRIPTION
This PR fixes #13.

Changes:
* Update docs with vagrant tests.
* Enabled restart of supervisor (needs latest supervisor conda role).