### PR TITLE
postgres db install is optional (#23)

### DIFF
--- a/docs/source/custom_playbook.rst
+++ b/docs/source/custom_playbook.rst
@@ -17,3 +17,15 @@ You can also add your custom configurtions to the ``etc/`` folder::
 
   $ vim etc/custom-emu.yml
   $ ln -s etc/custom-emu.yml custom.yml
+
+Use external Postgresql Database
+--------------------------------
+
+By default the playbook will install a postgresql database. If you want to use an
+existing database you can skip the installation by setting the variable::
+
+  db_install_postgresql: false
+
+You need to configure then the database connection string to external database::
+
+  wps_database: "postgresql+psycopg2://db_user:db_password@db_host:5432/pywps_db"

--- a/group_vars/all
+++ b/group_vars/all
@@ -13,8 +13,11 @@ conda_env_prefix: "{{ conda_envs_dir}}/{{ wps_name }}"
 gunicorn_etc_dir: /etc/gunicorn
 
 # postgres
-db_name: pywps_db
-db_user: wps
+db_install_postgresql: true
+db_name: "pywps_{{ wps_name }}"
+db_host: localhost
+db_port: 5432
+db_user: pywps
 db_password: wps
 
 # PyWPS
@@ -41,4 +44,4 @@ wps_parallelprocesses: 10
 # WPS logging
 wps_log_level: INFO
 wps_log_file: /var/log/pywps/{{ wps_name }}.log
-wps_database: postgresql+psycopg2://{{ db_user }}:{{ db_password }}@localhost:5432/{{ db_name }}
+wps_database: "postgresql+psycopg2://{{ db_user }}:{{ db_password }}@{{ db_host }}:{{ db_port }}/{{ db_name }}"

--- a/playbook.yml
+++ b/playbook.yml
@@ -27,6 +27,7 @@
       tags:
         nginx
     - role: geerlingguy.postgresql
+      when: db_install_postgresql
       tags:
         db
     - pywps

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,6 +13,8 @@ nginx_remove_default_vhost: True
 # postgres
 postgresql_databases:
   - name:  "{{ db_name }}"
+    login_host: "{{ db_host }}"
+    port: "{{ db_port }}"
 postgresql_users:
   - name: "{{ db_user }}"
     password: "{{ db_password }}"


### PR DESCRIPTION
This PR fixes issue #23.

Changes:
* Added variable `db_install_postgresql` to make postgres installation optional.
* Fixed db_name default value (unique for each WPS).
* Updated docs.