### PR TITLE
support for centos 6.x (#34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ etc/custom*.yml
 # external roles from ansible-galaxy
 roles/andrewrothstein.*
 roles/geerlingguy.*
+roles/ANXS.*
 roles/ansible-role-supervisor
 
 # temp files

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,16 @@ services: docker
 
 env:
   - distro: centos7
-  #- distro: fedora27
+  - distro: centos6
+  - distro: ubuntu1804
   #- distro: ubuntu1604
+  #- distro: fedora27
   #- distro: debian9
 
 script:
   # copy test config
   - cp ${PWD}/etc/sample-emu.yml ${PWD}/custom.yml
-  
+
   # Configure test script so we can run extra tests after playbook is run.
   - export container_id=$(date +%s)
   - export cleanup=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services: docker
 
 env:
   - distro: centos7
-  - distro: centos6
+  #- distro: centos6
   - distro: ubuntu1804
   #- distro: ubuntu1604
   #- distro: fedora27

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,10 @@ bootstrap() {
         sudo yum install -y epel-release
         sudo yum install -y gcc-c++ make
         sudo yum install -y ansible
+        if [ `grep -oE '[0-9]+\.' /etc/redhat-release` = "6." ] ; then
+          # needed for galaxy usage with python 2.6 on CentOS 6
+          sudo yum install -y python-urllib3 pyOpenSSL python2-ndg_httpsclient python-pyasn1
+        fi
     elif [ `uname -s` = "Darwin" ] ; then
         echo "Install Homebrew packages ..."
         brew install ansible

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -5,17 +5,27 @@ Links
     :local:
     :depth: 2
 
+
+Roles/Recipes from Ansible Galaxy
+---------------------------------
+
+Used roles:
+
+* miniconda: https://galaxy.ansible.com/andrewrothstein/miniconda/
+* nginx: https://galaxy.ansible.com/jdauphant/nginx/
+* supervisor: https://galaxy.ansible.com/geerlingguy/supervisor
+* postgresql: https://galaxy.ansible.com/anxs/postgresql
+
+Alternative roles:
+
+* postgresql: https://galaxy.ansible.com/geerlingguy/postgresql
+
+Other
+-----
+
 * https://tdhopper.com/blog/automating-python-with-ansible/
 * https://serversforhackers.com/c/an-ansible-tutorial
 * https://plone-ansible-playbook.readthedocs.io/en/latest/index.html
 * http://docs.ansible.com/ansible/latest/intro_installation.html
 * https://github.com/geocontainers/
 * http://pywps.readthedocs.io/en/master/deployment.html#deployment-on-nginx-gunicorn
-
-Roles/Recipes from Ansible Galaxy
----------------------------------
-
-* miniconda: https://galaxy.ansible.com/andrewrothstein/miniconda/
-* nginx: https://galaxy.ansible.com/jdauphant/nginx/
-* supervisor: https://galaxy.ansible.com/geerlingguy/supervisor
-* postgresql: https://galaxy.ansible.com/geerlingguy/postgresql

--- a/etc/sample-sqlite.yml
+++ b/etc/sample-sqlite.yml
@@ -1,0 +1,11 @@
+---
+# Use sqlite db
+db_install_postgresql: false
+db_install_sqlite: true
+# Configuration for Emu WPS
+wps_services:
+  - name: emu
+    # repo: https://github.com/bird-house/emu.git
+    # version: master
+    hostname: localhost
+    port: 5000

--- a/group_vars/all
+++ b/group_vars/all
@@ -6,6 +6,7 @@ src_dir: "{{ prefix }}/src"
 
 # postgres
 db_install_postgresql: true
+db_install_sqlite: false
 db_name: pywps
 db_host: localhost
 db_port: 5432
@@ -29,3 +30,4 @@ wps_services: []
   #   maxprocesses: 30
   #   parallelprocesses: 4
   #   log_level: INFO
+  #   database: {{ wps_database }}

--- a/playbook.yml
+++ b/playbook.yml
@@ -26,7 +26,7 @@
     - role: geerlingguy.nginx
       tags:
         nginx
-    - role: geerlingguy.postgresql
+    - role: ANXS.postgresql
       when: db_install_postgresql
       tags:
         db

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,4 +17,5 @@
 - src: geerlingguy.nginx
 
 # postgres from Ansible Galaxy
-- src: geerlingguy.postgresql
+# - src: geerlingguy.postgresql
+- src: ANXS.postgresql

--- a/roles/pywps/tasks/main.yml
+++ b/roles/pywps/tasks/main.yml
@@ -38,6 +38,16 @@
     - /etc/pywps
     - /var/log/pywps
     - /var/run/pywps
+    - /var/lib/pywps/db
+  tags:
+    - pywps
+    - conf
+
+- name: Create sqlite db folders used by PyWPS and set owner
+  file: path={{ item }} state=directory owner={{ wps_user }} group={{ wps_group }} mode=0755
+  with_items:
+    - /var/lib/pywps/db
+  when: db_install_sqlite
   tags:
     - pywps
     - conf
@@ -62,6 +72,15 @@
   file: path="/var/log/pywps/{{ item.name }}.log" state=touch owner={{ wps_user }} group={{ wps_group }} mode=0644
   with_items:
     - "{{ wps_services }}"
+  tags:
+    - pywps
+    - conf
+
+- name: Update sqlite db file permissions
+  file: path="/var/lib/pywps/db/{{ item.name }}_log.db" state=touch owner={{ wps_user }} group={{ wps_group }} mode=0644
+  with_items:
+    - "{{ wps_services }}"
+  when: db_install_sqlite
   tags:
     - pywps
     - conf

--- a/roles/pywps/templates/pywps.cfg
+++ b/roles/pywps/templates/pywps.cfg
@@ -12,5 +12,9 @@ workdir=/var/lib/pywps/tmp/{{ item.name }}
 [logging]
 level = {{ item.log_level | default('INFO') }}
 file = /var/log/pywps/{{ item.name }}.log
-database = {{ wps_database }}
+{% if db_install_sqlite %}
+database = sqlite:////var/lib/pywps/db/{{ item.name }}_log.db
+{% else %}
+database = {{ item.database | default(wps_database) }}
+{% endif %}
 format = %(asctime)s] [%(levelname)s] %(message)s

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,8 +18,9 @@ nginx_remove_default_vhost: True
 # postgres
 postgresql_databases:
   - name:  "{{ db_name }}"
-    login_host: "{{ db_host }}"
-    port: "{{ db_port }}"
 postgresql_users:
   - name: "{{ db_user }}"
-    password: "{{ db_password }}"
+    pass: "{{ db_password }}"
+postgresql_listen_addresses:
+  - "{{ db_host }}"
+postgresql_port: "{{ db_port }}"


### PR DESCRIPTION
This PR fixes #34.

Changes:

*  fixed `bootstrap.sh` for CentOS 6 to enable downloads of roles from Ansible Galaxy.
* added support for sqlite: `db_install_sqlite: false`.
* using `ANXS.postgresql` role with support for CentOS 6.
* enabled travis tests for CentOS 6/7 and Ubuntu 18.04.