### PR TITLE
make outputurl configurable

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -31,3 +31,4 @@ wps_services: []
   #   parallelprocesses: 4
   #   log_level: INFO
   #   database: {{ wps_database }}
+  #   outputurl: http://localhost:5000/outputs/emu

--- a/roles/pywps/templates/pywps.cfg
+++ b/roles/pywps/templates/pywps.cfg
@@ -1,6 +1,7 @@
 [server]
 url = http://{{ item.hostname | default('localhost') }}:{{ item.port }}/wps
-outputurl = http://{{ item.hostname | default('localhost' )}}:{{ item.port }}/outputs/{{ item.name }}
+{% set _outputurl = 'http://{}:{}/outputs/{}'.format(item.hostname, item.port, item.name) %}
+outputurl = {{ item.outputurl | default(_outputurl) }}
 allowedinputpaths = /
 maxsingleinputsize = {{ item.maxsingleinputsize | default('200mb') }}
 maxrequestsize = {{ item.maxrequestsize | default('200mb') }}


### PR DESCRIPTION
This PR allows to overwrite the default `outputurl` for each WPS installation.