### PR TITLE
fix pywps.cfg template for python 2.6 (#34)

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,4 @@
 enable_task_debugger = False
 log_path = ./ansible.log
 inventory = ./hosts
+roles_path = ./roles

--- a/docs/source/preparing.rst
+++ b/docs/source/preparing.rst
@@ -60,6 +60,11 @@ Configure your PyWPS installation. See :ref:`Configuration`:
 Run Ansible
 -----------
 
+.. warning::
+
+  Make sure your ansible directory is not world-readable, otherwise the `ansible.cfg` file will not be read.
+  See `Ansible Documentation <https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir>`_.
+
 Fetch required roles/recipes from ansible-galaxy:
 
 .. code-block:: sh

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -96,6 +96,24 @@ Configure ``Vagrantfile`` with another `Bento Box <https://app.vagrantup.com/ben
 
   wps.vm.box = "bento/ubuntu-18.04"
 
+Alternative: use Vagrant without provisioning
+---------------------------------------------
+
+Use Vagrant without privisioning and just to setup a new VM::
+
+  $ vagrant destroy -f  # remove previous VM
+  $ vagrant up --no-provision  # setup new VM
+  $ vagrant ssh  # ssh into VM
+
+Run the installation manually now::
+
+  vagrant> sudo yum install git
+  vagrant> git clone https://github.com/bird-house/ansible-wps-playbook.git
+  vagrant> cd ansible-wps-playbook
+  vagrant> ./bootstrap.sh
+  vagrant> ln -s etc/sample-vagrant.yml custom.yml
+  vagrant> ansible-galaxy install -r requirements.yml
+  vagrant> ansible-playbook -c local playbook.yml
 
 Test Ansible in a Docker container
 ----------------------------------

--- a/roles/pywps/templates/pywps.cfg
+++ b/roles/pywps/templates/pywps.cfg
@@ -1,6 +1,6 @@
 [server]
 url = http://{{ item.hostname | default('localhost') }}:{{ item.port }}/wps
-{% set _outputurl = 'http://{}:{}/outputs/{}'.format(item.hostname, item.port, item.name) %}
+{% set _outputurl = 'http://{0}:{1}/outputs/{2}'.format(item.hostname, item.port, item.name) %}
 outputurl = {{ item.outputurl | default(_outputurl) }}
 allowedinputpaths = /
 maxsingleinputsize = {{ item.maxsingleinputsize | default('200mb') }}


### PR DESCRIPTION
This PR adds a fix to issue #34.

Changes:

* Updated `pywps.cfg` template to support Python 2.6 on CentOS 6.
* Updated documentation with an example for Vagrant without provisioning.