### PR TITLE
enable https (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ roles/andrewrothstein.*
 roles/geerlingguy.*
 roles/ANXS.*
 roles/ansible-role-supervisor
+roles/jdauphant.ssl-certs
 
 # temp files
 *.retry

--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -1,3 +1,12 @@
+Ansible Hints
+=============
+
+Show local variables and facts:
+
+.. code-block:: sh
+
+  $ ansible -m setup -c local localhost
+
 Links
 =====
 

--- a/etc/sample-certs.yml
+++ b/etc/sample-certs.yml
@@ -1,5 +1,5 @@
 ---
-server_name: 192.168.128.100
+server_name: localhost
 wps_enable_https: true
 # Fileserver for WPS outputs
 fs_enabled: false

--- a/group_vars/all
+++ b/group_vars/all
@@ -24,6 +24,7 @@ fs_port: 6000
 wps_user: wps
 wps_group: "{{ wps_user }}"
 wps_database: "{{ db_connect }}"
+wps_enable_https: false
 wps_services: []
   # - name: emu
   #   repo: https://github.com/bird-house/emu.git

--- a/playbook.yml
+++ b/playbook.yml
@@ -23,6 +23,11 @@
     - role: geerlingguy.supervisor
       tags:
         supervisor
+    - role: jdauphant.ssl-certs
+      tags:
+        nginx
+      when: wps_enable_https
+    - certs
     - role: geerlingguy.nginx
       tags:
         nginx

--- a/requirements.yml
+++ b/requirements.yml
@@ -42,3 +42,9 @@
 # - src: ANXS.postgresql
 - src: https://github.com/ANXS/postgresql/archive/v1.10.1.tar.gz
   name: ANXS.postgresql
+
+# ssl-certs
+# ---------
+# - src: jdauphant.ssl-certs
+- src: https://github.com/jdauphant/ansible-role-ssl-certs/archive/v1.7.tar.gz
+  name: jdauphant.ssl-certs

--- a/roles/certs/tasks/main.yml
+++ b/roles/certs/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Download esgf-ca-bundle.crt
+  get_url:
+    url: "{{ ssl_certs_cacert_url }}"
+    dest:  "{{ ssl_certs_cacert_path }}"
+    mode: 0440
+  tags:
+    nginx
+  when: wps_enable_https

--- a/roles/common/tasks/Debian.yml
+++ b/roles/common/tasks/Debian.yml
@@ -2,6 +2,7 @@
   apt: name={{ item }} state=latest
   with_items:
     - build-essential
+    - libssl-dev
 
 - name: Remove unwanted packages on Debian
   apt: name={{ item }} state=absent

--- a/roles/common/tasks/RedHat.yml
+++ b/roles/common/tasks/RedHat.yml
@@ -6,6 +6,7 @@
     - libselinux-python
     - initscripts
     - python-meld3
+    - openssl-devel
 
 - name: Remove unwanted packages on RedHat
   yum: name={{ item }} state=absent

--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -5,8 +5,20 @@ upstream {{ item.name }} {
 }
 
 server {
-    listen {{ item.port }};
-    server_name {{ item.hostname | default('localhost') }};
+    {% if wps_enable_https %}
+    listen                 {{ item.port | default('5000') }} ssl;
+    {% else %}
+    listen                 {{ item.port | default('5000') }};
+    {% endif %}
+    server_name            {{ item.hostname | default('localhost') }};
+    {% if wps_enable_https %}
+    ssl_certificate        {{ ssl_certs_cert_path }};
+    ssl_certificate_key    {{ ssl_certs_privkey_path }};
+    #ssl_crl               ca.crl;
+    ssl_client_certificate {{ ssl_certs_cacert_path }};
+    ssl_verify_client      {{ ssl_certs_verify_client }};
+    ssl_verify_depth       2;
+    {% endif %}
 
     # better to redirect / to wps application
     location / {
@@ -20,6 +32,9 @@ server {
         proxy_set_header        X-Forwarded-Host $host/wps/;
         proxy_set_header        X-Forwarded-Server $host;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-SSL-Client-Cert $ssl_client_escaped_cert;
+        proxy_set_header        X-SSL-Client-Verify $ssl_client_verify;
+        proxy_set_header        X-SSL-Client-S-DN $ssl_client_s_dn;
         proxy_redirect          off;
         proxy_buffering         on;
         client_max_body_size    64m;

--- a/roles/pywps/templates/pywps.cfg
+++ b/roles/pywps/templates/pywps.cfg
@@ -1,9 +1,14 @@
 [server]
-url = http://{{ item.hostname | default('localhost') }}:{{ item.port }}/wps
+{% if wps_enable_https %}
+{% set _protocol = 'https' %}
+{% else %}
+{% set _protocol = 'http' %}
+{% endif %}
+url = {{ _protocol }}://{{ item.hostname | default('localhost') }}:{{ item.port }}/wps
 {% if fs_enabled %}
 {% set _outputurl = 'http://{0}:{1}/outputs/{2}'.format(fs_host, fs_port, item.name) %}
 {% else %}
-{% set _outputurl = 'http://{0}:{1}/outputs/{2}'.format(item.hostname, item.port, item.name) %}
+{% set _outputurl = '{0}://{1}:{2}/outputs/{3}'.format(_protocol, item.hostname, item.port, item.name) %}
 {% endif %}
 outputurl = {{ item.outputurl | default(_outputurl) }}
 allowedinputpaths = /

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,3 +24,9 @@ postgresql_users:
 postgresql_listen_addresses:
   - "{{ db_host }}"
 postgresql_port: "{{ db_port }}"
+# ssl-certs
+ssl_certs_path_owner: "{{ wps_user }}"
+ssl_certs_path_group: "{{ wps_group }}"
+ssl_certs_cacert_path: "{{ ssl_certs_path }}/cacert.crt"
+ssl_certs_verify_client: "optional"
+ssl_certs_cacert_url: "https://github.com/ESGF/esgf-dist/raw/master/installer/certs/esgf-ca-bundle.crt"


### PR DESCRIPTION
This PR fixes issue #30.

Changes:
* Added variable `wps_enable_https` to configure Nginx with HTTPS.
* Added role `jdauphant.ssl-certs` to generated self-signed certs or add local certs.
* Allow SSL client certificate verification.