### PR TITLE
sethomedir (#30)

### DIFF
--- a/etc/sample-certs.yml
+++ b/etc/sample-certs.yml
@@ -10,3 +10,4 @@ wps_services:
   - name: emu
     hostname: "{{ server_name }}"
     port: 5000
+    sethomedir: true

--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -32,7 +32,7 @@ server {
         proxy_set_header        X-Forwarded-Host $host/wps/;
         proxy_set_header        X-Forwarded-Server $host;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header        X-SSL-Client-Cert $ssl_client_escaped_cert;
+        # proxy_set_header        X-SSL-Client-Cert $ssl_client_escaped_cert;
         proxy_set_header        X-SSL-Client-Verify $ssl_client_verify;
         proxy_set_header        X-SSL-Client-S-DN $ssl_client_s_dn;
         proxy_redirect          off;

--- a/roles/pywps/templates/pywps.cfg
+++ b/roles/pywps/templates/pywps.cfg
@@ -18,6 +18,7 @@ maxprocesses = {{ item.maxprocesses | default('30') }}
 parallelprocesses = {{ item.parallelprocesses | default('4') }}
 outputpath= /var/lib/pywps/outputs/{{ item.name }}
 workdir=/var/lib/pywps/tmp/{{ item.name }}
+sethomedir={{ item.sethomedir | default('false') }}
 
 [logging]
 level = {{ item.log_level | default('INFO') }}


### PR DESCRIPTION
This PR is an update to issue #30.

Changes:
* `sethomedir` in pywps config can be set.
* disabled `Http-X-Ssl-Client-Cert` in nginx config.

Changes are necessary to transfer proxy certificate for opendap. 