### PR TITLE
fix package install

### DIFF
--- a/roles/common/tasks/Debian.yml
+++ b/roles/common/tasks/Debian.yml
@@ -1,10 +1,16 @@
 - name: Install common packages on Debian
-  apt: name={{ item }} state=latest
-  with_items:
-    - build-essential
-    - libssl-dev
+  apt:
+    name: "{{ packages }}"
+    state: latest
+  vars:
+    packages:
+      - build-essential
+      - libssl-dev
 
 - name: Remove unwanted packages on Debian
-  apt: name={{ item }} state=absent
-  with_items:
-    - supervisor
+  apt:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+      - supervisor

--- a/roles/common/tasks/RedHat.yml
+++ b/roles/common/tasks/RedHat.yml
@@ -1,14 +1,20 @@
 - name: Install common packages on RedHat
-  yum: name={{ item }} state=latest
-  with_items:
-    - gcc-c++
-    - make
-    - libselinux-python
-    - initscripts
-    - python-meld3
-    - openssl-devel
+  yum:
+    name: "{{ packages }}"
+    state: latest
+  vars:
+    packages:
+      - gcc-c++
+      - make
+      - libselinux-python
+      - initscripts
+      - python-meld3
+      - openssl-devel
 
 - name: Remove unwanted packages on RedHat
-  yum: name={{ item }} state=absent
-  with_items:
-    - supervisor
+  yum:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+      - supervisor


### PR DESCRIPTION
This PR updates the package installation for `yum` and `apt`. Using loops is deprecated.