### PR TITLE
added user uid/gid to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ roles/geerlingguy.*
 roles/ANXS.*
 roles/ansible-role-supervisor
 roles/jdauphant.ssl-certs
+roles/nginxinc.nginx
 
 # temp files
 *.retry

--- a/etc/sample-cp4cds_load-balancer.yml
+++ b/etc/sample-cp4cds_load-balancer.yml
@@ -1,8 +1,12 @@
 ---
 wps_external_hostname: compute.mips.copernicus-climate.eu
 wps_internal_hostname: cp4cds-cn1.somewhere.org
+wps_add_user: true
 wps_user: wps
+# wps_uid: 1000
+# wps_user_home: /var/lib/pywps
 wps_group: wps
+# wps_gid: 1000
 wps_port: 80
 wps_services:
   - name: c4cds

--- a/group_vars/all
+++ b/group_vars/all
@@ -23,7 +23,10 @@ fs_port: 6000
 # WPS
 wps_add_user: true
 wps_user: wps
+# wps_uid: 1000
+wps_user_home: /var/lib/pywps
 wps_group: "{{ wps_user }}"
+# wps_gid: 1000
 wps_database: "{{ db_connect }}"
 wps_enable_https: false
 wps_services: []

--- a/requirements.yml
+++ b/requirements.yml
@@ -34,7 +34,7 @@
 # nginx
 # -----
 # - src: geerlingguy.nginx
-- src: https://github.com/geerlingguy/ansible-role-nginx/archive/2.6.0.tar.gz
+- src: https://github.com/geerlingguy/ansible-role-nginx/archive/2.6.2.tar.gz
   name: geerlingguy.nginx
 
 # postgresql

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,14 +17,16 @@
 - name: Add WPS group
   group:
     name: "{{ wps_group }}"
+    gid: "{{ wps_gid | default(omit) }}"
     state: present
 
 - name: Add WPS user
   user:
     name: "{{ wps_user }}"
+    uid: "{{ wps_uid | default(omit) }}"
     groups: "{{ wps_group }}"
     system: yes
     shell: /sbin/nologin
     createhome: no
-    home: /var/lib/pywps
+    home: "{{ wps_user_home }}"
   when: wps_add_user


### PR DESCRIPTION
This PR adds the wps user uid/gid options to the `group_vars/all` config. uid/gid can be omitted and will be set automatically when not set.

Fix #56.