### PR TITLE
Issue 71 use conda spec

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -23,6 +23,22 @@ You can also add your custom configurations to the ``etc/`` folder to stay away 
   $ vim etc/custom-emu.yml
   $ ln -s etc/custom-emu.yml custom.yml
 
+Use Conda to build identical environments
+-----------------------------------------
+
+You can use Conda specification files to build identical environments_.
+The WPS service needs to have a specification file, ``spec-file.txt``, in its top level folder.
+You can set the following option in your ``custom.yml``::
+
+  conda_env_use_spec: true
+
+See an example in ``etc/sample-emu-with-conda-spec.yml``.
+
+.. warning:: Conda spec files will work only on a specifc OS, in our case Linux.
+
+.. _`environments`: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#building-identical-conda-environments
+
+
 Use external PostgreSQL Database
 --------------------------------
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -34,7 +34,10 @@ You can set the following option in your ``custom.yml``::
 
 See an example in ``etc/sample-emu-with-conda-spec.yml``.
 
-.. warning:: Conda spec files will work only on a specifc OS, in our case Linux.
+.. warning:: This is option is currently enabled for `all` configured WPS services.
+
+.. note:: Conda spec files will work only on a specifc OS, in our case Linux.
+
 
 .. _`environments`: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#building-identical-conda-environments
 

--- a/etc/sample-emu-with-conda-spec.yml
+++ b/etc/sample-emu-with-conda-spec.yml
@@ -1,0 +1,10 @@
+---
+# Conda spec
+conda_env_use_spec: true
+# Configuration for Emu WPS
+wps_services:
+  - name: emu
+    # repo: https://github.com/bird-house/emu.git
+    # version: master
+    hostname: localhost
+    port: 5000

--- a/etc/sample-vagrant.yml
+++ b/etc/sample-vagrant.yml
@@ -5,6 +5,8 @@ wps_enable_https: false
 fs_enabled: false
 # fs_host: "{{ server_name }}"
 # fs_port: 5001
+# Conda spec
+conda_env_use_spec: true
 # Configuration for Emu WPS
 wps_services:
   - name: emu

--- a/etc/sample-vagrant.yml
+++ b/etc/sample-vagrant.yml
@@ -6,7 +6,7 @@ fs_enabled: false
 # fs_host: "{{ server_name }}"
 # fs_port: 5001
 # Conda spec
-conda_env_use_spec: true
+# conda_env_use_spec: false
 # Configuration for Emu WPS
 wps_services:
   - name: emu

--- a/roles/pywps/tasks/conda.yml
+++ b/roles/pywps/tasks/conda.yml
@@ -4,8 +4,8 @@
   args:
     chdir: "{{ src_dir }}/{{ item.name }}"
   with_items: "{{ wps_services }}"
-  when: not conda_env_use_spec and git.changed
-  register: conda
+  when: not conda_env_use_spec
+  register: conda_env
   tags:
     - pywps
     - conda
@@ -13,18 +13,25 @@
 - name: Install additional Conda packages.
   command: "{{ conda_location }}/bin/conda install -y -p {{ conda_envs_dir}}/{{ item.name }} gunicorn psycopg2"
   with_items: "{{ wps_services }}"
-  when: not conda_env_use_spec and conda.changed
+  when: conda_env.changed
   tags:
     - pywps
     - conda
 
-- name: Create Conda environment form spec-file.txt file.
+- name: Remove Conda environment.
+  command: "{{ conda_location }}/bin/conda env remove -q -y -p {{ conda_envs_dir}}/{{ item.name }}"
+  with_items: "{{ wps_services }}"
+  when: conda_env_use_spec
+  tags:
+    - pywps
+    - conda
+
+- name: Create Conda environment from spec-file.txt file.
   command: "{{ conda_location }}/bin/conda create --file {{ conda_env_spec_file }} -p {{ conda_envs_dir}}/{{ item.name }}"
   args:
     chdir: "{{ src_dir }}/{{ item.name }}"
   with_items: "{{ wps_services }}"
-  when: conda_env_use_spec and git.changed
-  register: conda
+  when: conda_env_use_spec
   tags:
     - pywps
     - conda

--- a/roles/pywps/tasks/conda.yml
+++ b/roles/pywps/tasks/conda.yml
@@ -4,7 +4,7 @@
   args:
     chdir: "{{ src_dir }}/{{ item.name }}"
   with_items: "{{ wps_services }}"
-  when: git.changed
+  when: not conda_env_use_spec and git.changed
   register: conda
   tags:
     - pywps
@@ -13,7 +13,18 @@
 - name: Install additional Conda packages.
   command: "{{ conda_location }}/bin/conda install -y -p {{ conda_envs_dir}}/{{ item.name }} gunicorn psycopg2"
   with_items: "{{ wps_services }}"
-  when: conda.changed
+  when: not conda_env_use_spec and conda.changed
+  tags:
+    - pywps
+    - conda
+
+- name: Create Conda environment form spec-file.txt file.
+  command: "{{ conda_location }}/bin/conda create --file {{ conda_env_spec_file }} -p {{ conda_envs_dir}}/{{ item.name }}"
+  args:
+    chdir: "{{ src_dir }}/{{ item.name }}"
+  with_items: "{{ wps_services }}"
+  when: conda_env_use_spec and git.changed
+  register: conda
   tags:
     - pywps
     - conda

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,6 +4,8 @@ miniconda_make_sys_default: False
 # conda
 conda_location: "{{ prefix }}/anaconda"
 conda_envs_dir: "{{ conda_location }}/envs"
+conda_env_use_spec: false
+conda_env_spec_file: spec-file.txt
 # supervisor
 supervisor_user: root
 supervisor_password: 'test'


### PR DESCRIPTION
This PR fixes issues #71.

Changes:
* adds option `conda_env_use_spec` to use conda spec file.
* updated docs.
* skipped `git.changed` condition for conda tasks.