### PR TITLE
fix service restart

### DIFF
--- a/roles/pywps/tasks/folders.yml
+++ b/roles/pywps/tasks/folders.yml
@@ -5,7 +5,6 @@
     - /etc/gunicorn
     - /etc/pywps
     - /var/log/pywps
-    - /var/run/pywps
     - /var/lib/pywps/db
   tags:
     - pywps

--- a/roles/pywps/templates/gunicorn.py.j2
+++ b/roles/pywps/templates/gunicorn.py.j2
@@ -1,4 +1,4 @@
-bind = 'unix:///var/run/pywps/{{ item.name }}.socket'
+bind = 'unix:///var/lib/pywps/{{ item.name }}.sock'
 workers = 3
 worker_class = 'sync'
 
@@ -8,7 +8,7 @@ raw_env = [
 ]
 
 # logging
-debug = True
+accesslog = '-'
 errorlog = '-'
 loglevel = 'INFO'
-accesslog = '-'
+capture_output = True

--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -1,7 +1,7 @@
 # pywps web processing service
 upstream {{ item.name }} {
     # socket connection
-    server unix:///var/run/pywps/{{ item.name }}.socket fail_timeout=0;
+    server unix:///var/lib/pywps/{{ item.name }}.sock fail_timeout=0;
 }
 
 server {

--- a/roles/twitcher/tasks/folders.yml
+++ b/roles/twitcher/tasks/folders.yml
@@ -3,7 +3,6 @@
   file: path={{ item }} state=directory owner={{ twitcher_user }} group={{ twitcher_group }} mode=0755
   with_items:
     - /var/lib/twitcher
-    - /var/run
   tags:
     - twitcher
     - conf

--- a/roles/twitcher/templates/nginx.conf.j2
+++ b/roles/twitcher/templates/nginx.conf.j2
@@ -1,6 +1,6 @@
 # Twitcher: a pyramid app for ows proxy
 upstream twitcher {
-    server unix:/var/run/twitcher.sock fail_timeout=0;
+    server {{ twitcher_bind }} fail_timeout=0;
 }
 
 # https server

--- a/roles/twitcher/templates/twitcher.ini.j2
+++ b/roles/twitcher/templates/twitcher.ini.j2
@@ -46,7 +46,7 @@ file_template = %%(year)d%%(month).2d%%(day).2d_%%(rev)s
 
 [server:main]
 use = egg:gunicorn#main
-bind = unix:/var/run/twitcher.sock
+bind = {{ twitcher_bind }}
 workers = 3
 preload = true
 reload = true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -55,3 +55,4 @@ twitcher_ows_proxy_delegate: false
 twitcher_ows_proxy_url: true
 twitcher_ows_proxy_protected_path: "/ows"
 twitcher_ssl_verify_client: "optional"
+twitcher_bind: "unix:/var/lib/twitcher/twitcher.sock"


### PR DESCRIPTION
This PR fixes issue #54.

Changes:
* socket is created in `/var/lib/pywps` and `/var/lib/twitcher`.
* update gunicorn config.