### PR TITLE
added tmpfiles.d config for pywps and twitcher

### DIFF
--- a/roles/pywps/tasks/config.yml
+++ b/roles/pywps/tasks/config.yml
@@ -1,4 +1,12 @@
 ---
+- name: Copy tmpfiles.d config
+  template:
+    src: ./templates/tmpfiles.config.j2
+    dest: "/usr/lib/tmpfiles.d/pywps.cfg"
+  tags:
+    - pywps
+    - conf
+
 - name: Copy pywps config
   template:
     src: ./templates/pywps.cfg.j2

--- a/roles/pywps/tasks/folders.yml
+++ b/roles/pywps/tasks/folders.yml
@@ -4,6 +4,7 @@
   with_items:
     - /etc/gunicorn
     - /etc/pywps
+    - "{{ wps_run_dir }}"
     - /var/log/pywps
     - /var/lib/pywps/db
   tags:

--- a/roles/pywps/templates/gunicorn.py.j2
+++ b/roles/pywps/templates/gunicorn.py.j2
@@ -1,4 +1,4 @@
-bind = 'unix:///var/lib/pywps/{{ item.name }}.sock'
+bind = 'unix://{{ wps_run_dir }}/{{ item.name }}.sock'
 workers = 3
 worker_class = 'sync'
 

--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -1,7 +1,7 @@
 # pywps web processing service
 upstream {{ item.name }} {
     # socket connection
-    server unix:///var/lib/pywps/{{ item.name }}.sock fail_timeout=0;
+    server unix://{{ wps_run_dir }}/{{ item.name }}.sock fail_timeout=0;
 }
 
 server {

--- a/roles/pywps/templates/tmpfiles.config.j2
+++ b/roles/pywps/templates/tmpfiles.config.j2
@@ -1,0 +1,1 @@
+d {{ wps_run_dir }} 0755 {{ wps_user }} {{ wps_group }} -

--- a/roles/twitcher/tasks/config.yml
+++ b/roles/twitcher/tasks/config.yml
@@ -1,4 +1,12 @@
 ---
+- name: Copy tmpfiles.d config
+  template:
+    src: ./templates/tmpfiles.config.j2
+    dest: "/usr/lib/tmpfiles.d/twitcher.cfg"
+  tags:
+    - twitcher
+    - conf
+
 - name: Copy twitcher config
   template:
     src: ./templates/twitcher.ini.j2

--- a/roles/twitcher/tasks/folders.yml
+++ b/roles/twitcher/tasks/folders.yml
@@ -2,6 +2,7 @@
 - name: Create folders used by twitcher and set owner
   file: path={{ item }} state=directory owner={{ twitcher_user }} group={{ twitcher_group }} mode=0755
   with_items:
+    - "{{ twitcher_run_dir }}"
     - /var/lib/twitcher
   tags:
     - twitcher

--- a/roles/twitcher/templates/tmpfiles.config.j2
+++ b/roles/twitcher/templates/tmpfiles.config.j2
@@ -1,0 +1,1 @@
+d {{ wps_run_dir }} 0755 {{ wps_user }} {{ wps_group }} -

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -39,6 +39,7 @@ ssl_certs_cacert_url: "https://github.com/ESGF/esgf-dist/raw/master/installer/ce
 wps_user: "{{ service_user }}"
 wps_group: "{{ service_group }}"
 wps_enable_https: "{{ service_enable_https }}"
+wps_run_dir: /run/pywps
 # twitcher
 twitcher_version: "master"
 twitcher_user: "{{ service_user }}"
@@ -56,4 +57,5 @@ twitcher_ows_proxy_delegate: false
 twitcher_ows_proxy_url: true
 twitcher_ows_proxy_protected_path: "/ows"
 twitcher_ssl_verify_client: "optional"
-twitcher_bind: "unix:/var/lib/twitcher/twitcher.sock"
+twitcher_run_dir: /run/twitcher
+twitcher_bind: "unix:{{ twitcher_run_dir }}/twitcher.sock"


### PR DESCRIPTION
This PR fixes #78. It adds a `tmpfiles.d` config for both pywps and twitcher to create `/run/pywps` and `/run/twitcher` folders.