### PR TITLE
fix tmpfiles config

### DIFF
--- a/roles/pywps/tasks/config.yml
+++ b/roles/pywps/tasks/config.yml
@@ -2,7 +2,7 @@
 - name: Copy tmpfiles.d config
   template:
     src: ./templates/tmpfiles.config.j2
-    dest: "/usr/lib/tmpfiles.d/pywps.cfg"
+    dest: "/usr/lib/tmpfiles.d/pywps.conf"
   tags:
     - pywps
     - conf

--- a/roles/twitcher/tasks/config.yml
+++ b/roles/twitcher/tasks/config.yml
@@ -2,7 +2,7 @@
 - name: Copy tmpfiles.d config
   template:
     src: ./templates/tmpfiles.config.j2
-    dest: "/usr/lib/tmpfiles.d/twitcher.cfg"
+    dest: "/usr/lib/tmpfiles.d/twitcher.conf"
   tags:
     - twitcher
     - conf


### PR DESCRIPTION
This PR fixes the `tmpfiles.d` configuration name.

See #78 and PR #80.