### PR TITLE
fix ssl client verification

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -117,8 +117,14 @@ is also activated.
 
 Edit the following variables to change the behaviour::
 
+  ssl_certs_enable_verify_client: true
   ssl_certs_verify_client: "optional"
   ssl_certs_cacert_url: "https://github.com/ESGF/esgf-dist/raw/master/installer/certs/esgf-ca-bundle.crt"
+
+This behaviour is only available for twitcher::
+
+  twitcher_enabled: true
+  twitcher_enable_https: true
 
 Extend PyWPS configuration
 --------------------------

--- a/etc/sample-emu-with-twitcher.yml
+++ b/etc/sample-emu-with-twitcher.yml
@@ -1,6 +1,5 @@
 ---
 server_name: 192.168.128.100
-service_enable_https: true
 db_install_postgresql: true
 db_install_sqlite: false
 # Enable separate Fileserver for WPS outputs

--- a/etc/sample-vagrant.yml
+++ b/etc/sample-vagrant.yml
@@ -1,11 +1,10 @@
 ---
 server_name: 192.168.128.100
-service_enable_https: false
 db_install_postgresql: true
 db_install_sqlite: false
 #db_user: dbuser
 #db_password: dbuser
-# wps_enable_https: false
+wps_enable_https: false
 # Enable separate Fileserver for WPS outputs
 # fs_enabled: false
 # fs_host: "{{ server_name }}"
@@ -18,9 +17,7 @@ wps_services:
     hostname: "{{ server_name }}"
     fs_hostname: "{{ server_name }}"
     port: 5000
-    extra_config: |
-      [data]
-      cache_path = /tmp/cache
 # twitcher
 twitcher_enabled: false
-#twitcher_enable_https: false
+twitcher_enable_https: false
+ssl_certs_enable_verify_client: false

--- a/group_vars/all
+++ b/group_vars/all
@@ -11,8 +11,6 @@ service_group: "{{ service_user }}"
 service_groups: "{{ service_group }}"
 # service_gid: 100
 service_user_home: /var/lib/pywps
-# https
-service_enable_https: False
 
 # postgres
 db_install_postgresql: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -26,8 +26,6 @@
     - role: jdauphant.ssl-certs
       tags:
         nginx
-      when: service_enable_https
-    - certs
     - role: geerlingguy.nginx
       tags:
         nginx

--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -14,10 +14,6 @@ server {
     {% if wps_enable_https %}
     ssl_certificate        {{ ssl_certs_cert_path }};
     ssl_certificate_key    {{ ssl_certs_privkey_path }};
-    #ssl_crl               ca.crl;
-    ssl_client_certificate {{ ssl_certs_cacert_path }};
-    ssl_verify_client      {{ ssl_certs_verify_client }};
-    ssl_verify_depth       2;
     {% endif %}
 
     # better to redirect / to wps application

--- a/roles/twitcher/tasks/certs.yml
+++ b/roles/twitcher/tasks/certs.yml
@@ -5,4 +5,4 @@
     mode: 0440
   tags:
     nginx
-  when: service_enable_https
+  when: twitcher_enable_https and ssl_certs_enable_verify_client

--- a/roles/twitcher/tasks/main.yml
+++ b/roles/twitcher/tasks/main.yml
@@ -20,6 +20,9 @@
 - include: supervisor.yml
   when: twitcher_enabled
 
+- include: certs.yml
+  when: twitcher_enabled
+
 - include: nginx.yml
   when: twitcher_enabled
 

--- a/roles/twitcher/templates/nginx.conf.j2
+++ b/roles/twitcher/templates/nginx.conf.j2
@@ -20,10 +20,11 @@ server
     ssl_ciphers         HIGH:!aNULL:!MD5;
     ssl_session_cache   shared:SSL:1m;
     ssl_session_timeout 1m;
-    #ssl_crl               ca.crl;
+    {% if ssl_certs_enable_verify_client %}
     ssl_client_certificate {{ ssl_certs_cacert_path }};
     ssl_verify_client      {{ ssl_certs_verify_client }};
-    ssl_verify_depth       2;
+    ssl_verify_depth       3;
+    {% endif %}
     {% endif %}
 
     # app

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -35,6 +35,7 @@ ssl_certs_path_group: "{{ service_group }}"
 ssl_certs_cacert_path: "{{ ssl_certs_path }}/cacert.crt"
 ssl_certs_verify_client: "optional"
 ssl_certs_cacert_url: "https://github.com/ESGF/esgf-dist/raw/master/installer/certs/esgf-ca-bundle.crt"
+ssl_certs_enable_verify_client: false
 # pywps
 wps_user: "{{ service_user }}"
 wps_group: "{{ service_group }}"
@@ -58,6 +59,5 @@ twitcher_token_certfile: 'cert.pem'
 twitcher_token_expires_in: 3600
 twitcher_token_issuer: 'twitcher'
 twitcher_token_secret: '8aa3d8b07a374d3eb0c47c7464da7cb5'
-twitcher_ssl_verify_client: "optional"
 twitcher_run_dir: /run/twitcher
 twitcher_bind: "unix:{{ twitcher_run_dir }}/twitcher.sock"


### PR DESCRIPTION
This PR fixes issue #83.

Changes:
* sets nginx config `ssl_verify_depth       3;`
* ssl client verification only for twitcher and `ssl_certs_enable_verify_client: true`
* skips unused `service_enable_https`
* updated docs.