### PR TITLE
Fix demo mode

### DIFF
--- a/etc/vagrant-cluster-with-rook.yml
+++ b/etc/vagrant-cluster-with-rook.yml
@@ -1,7 +1,8 @@
 ---
 demo: true
 data_dir: /vagrant/.local/data
-epel_repo_disable: true
+# rm /etc/yum.repos.d/epel.repo to re-run when changed
+epel_repo_disable: false
 db_install_postgresql: true
 db_install_sqlite: false
 db_host: "192.168.50.44"

--- a/etc/vagrant-cluster-with-rook.yml
+++ b/etc/vagrant-cluster-with-rook.yml
@@ -1,6 +1,7 @@
 ---
 demo: true
-data_dir: /vagrant/.local/data/mini-esgf-data/test_data
+data_dir: /vagrant/.local/data
+epel_repo_disable: true
 db_install_postgresql: true
 db_install_sqlite: false
 db_host: "192.168.50.44"

--- a/group_vars/all
+++ b/group_vars/all
@@ -13,6 +13,9 @@ service_groups: "{{ service_group }}"
 # service_gid: 100
 service_user_home: /var/lib/pywps
 
+# RedHat/CentOS epel repo
+epel_repo_disable: false
+
 # postgres
 db_install_postgresql: true
 db_install_sqlite: false

--- a/playbook.yml
+++ b/playbook.yml
@@ -36,7 +36,7 @@
     - name: pywps
       wps_webservice_enabled: true
     - name: demo
-      when: demo 
+      when: demo
 
 - name: Install a PyWPS worker
   hosts: worker

--- a/roles/demo/tasks/main.yml
+++ b/roles/demo/tasks/main.yml
@@ -3,7 +3,7 @@
   git:
     repo: "https://github.com/roocs/mini-esgf-data.git"
     version: "master"
-    dest: "/vagrant/.local/data/mini-esgf-data"
+    dest: "{{ data_dir }}/mini-esgf-data"
     update: yes
     force: yes
   run_once: true

--- a/roles/pywps/tasks/config.yml
+++ b/roles/pywps/tasks/config.yml
@@ -17,10 +17,20 @@
     - pywps
     - conf
 
-- name: Copy roocs config
+- name: Copy roocs demo config
+  template:
+    src: ./templates/roocs.demo.ini.j2
+    dest: "/etc/roocs.ini"
+  tags:
+    - roocs
+    - conf
+  when: demo
+
+- name: Copy roocs production config
   template:
     src: ./templates/roocs.ini.j2
     dest: "/etc/roocs.ini"
   tags:
     - roocs
     - conf
+  when: not demo

--- a/roles/pywps/templates/roocs.demo.ini.j2
+++ b/roles/pywps/templates/roocs.demo.ini.j2
@@ -1,0 +1,17 @@
+[project:cmip5]
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cmip5/data
+
+[project:cmip6]
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cmip6/data
+
+[project:cordex]
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cordex/data
+
+[project:c3s-cmip5]
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data
+
+[project:c3s-cmip6]
+base_dir = NOT DEFINED YET
+
+[project:c3s-cordex]
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data

--- a/roles/pywps/templates/roocs.ini.j2
+++ b/roles/pywps/templates/roocs.ini.j2
@@ -1,17 +1,17 @@
 [project:cmip5]
-base_dir = {{ data_dir }}/badc/cmip5/data
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cmip5/data
 
 [project:cmip6]
-base_dir = {{ data_dir }}/badc/cmip6/data
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cmip6/data
 
 [project:cordex]
-base_dir = {{ data_dir }}/badc/cordex/data
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cordex/data
 
 [project:c3s-cmip5]
-base_dir = {{ data_dir }}/group_workspaces/jasmin2/cp4cds1/vol1/data
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data
 
 [project:c3s-cmip6]
 base_dir = NOT DEFINED YET
 
 [project:c3s-cordex]
-base_dir = {{ data_dir }}/group_workspaces/jasmin2/cp4cds1/vol1/data
+base_dir = {{ data_dir }}/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data

--- a/roles/pywps/templates/roocs.ini.j2
+++ b/roles/pywps/templates/roocs.ini.j2
@@ -1,17 +1,17 @@
 [project:cmip5]
-base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cmip5/data
+base_dir = /badc/cmip5/data
 
 [project:cmip6]
-base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cmip6/data
+base_dir = /badc/cmip6/data
 
 [project:cordex]
-base_dir = {{ data_dir }}/mini-esgf-data/test_data/badc/cordex/data
+base_dir = /badc/cordex/data
 
 [project:c3s-cmip5]
-base_dir = {{ data_dir }}/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data
+base_dir = /group_workspaces/jasmin2/cp4cds1/vol1/data
 
 [project:c3s-cmip6]
 base_dir = NOT DEFINED YET
 
 [project:c3s-cordex]
-base_dir = {{ data_dir }}/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/vol1/data
+base_dir = /group_workspaces/jasmin2/cp4cds1/vol1/data


### PR DESCRIPTION
Changes:
* Use `data_dir` in demo mode to install `mini_esgf_data`.
* Added `roocs.demo.ini` template using `data_dir` in demo mode.
* Using `roocs.ini` template in normal mode.
* Added example with `epel_repo_disable: false`. See: [ansible-role-repo-epel](https://github.com/geerlingguy/ansible-role-repo-epel#role-variables)