### PR TITLE
added inital health check endpoint

### DIFF
--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -46,4 +46,11 @@ server {
     }
     {% endif %}
 
+    # endpoint for load-balancer health checks
+    location /health
+    {
+        access_log off;
+        return 200 "healthy\n";
+    }
+
 }


### PR DESCRIPTION
This PR adds a `health/` endpoint to be used by load-balancers. It currently just reports that the service is running.