### PR TITLE
Add cronjob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
   #- distro: fedora27
   #- distro: debian9
 
+addons:
+  yum:
+    packages: cronie
+
 script:
   # copy test config
   - cp ${PWD}/etc/sample-emu.yml ${PWD}/custom.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ env:
   #- distro: fedora27
   #- distro: debian9
 
-addons:
-  yum:
-    packages: cronie
-
 script:
   # copy test config
   - cp ${PWD}/etc/sample-emu.yml ${PWD}/custom.yml

--- a/group_vars/all
+++ b/group_vars/all
@@ -93,6 +93,8 @@ wps_run_dir: /run/pywps
 wps_database: "postgresql+psycopg2://{{ db_user }}:{{ db_password }}@{{ db_host }}:{{ db_port }}/pywps"
 wps_webservice_enabled: true
 wps_basedir: "{{ service_user_home }}"
+wps_cronjob_disabled: yes
+wps_outputs_keep_days: 30
 wps_services: []
   # - name: emu
   #   repo: https://github.com/bird-house/emu.git

--- a/roles/common/tasks/RedHat.yml
+++ b/roles/common/tasks/RedHat.yml
@@ -10,6 +10,7 @@
       - initscripts
       - python-meld3
       - openssl-devel
+      - cronie
 
 - name: Remove unwanted packages on RedHat
   yum:

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -1,0 +1,20 @@
+---
+- name: Clear wps outputs
+  cron:
+    name: "clear wps outputs"
+    special_time: daily
+    user: root
+    job: "find {{ wps_basedir }}/outputs/* -maxdepth 1 -mtime +{{ wps_outputs_keep_days }} -exec rm -rf {} \\;"
+    cron_file: ansible_wps-clear-outputs
+    disabled: "{{ wps_cronjob_disabled }}"
+    state: present
+
+- name: Clear wps tempfiles
+  cron:
+    name: "clear wps tempfiles"
+    special_time: daily
+    user: root
+    job: "find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -exec rm -rf {} \\;"
+    cron_file: ansible_wps-clear-tempfiles
+    disabled: "{{ wps_cronjob_disabled }}"
+    state: present

--- a/roles/pywps/tasks/webservice.yml
+++ b/roles/pywps/tasks/webservice.yml
@@ -1,5 +1,6 @@
 ---
 - include: clean.yml
+- include: cronjob.yml
 - include: webservice_config.yml
 
 - include: slurm.yml

--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -46,4 +46,11 @@ server {
     }
     {% endif %}
 
+    # endpoint for load-balancer health checks
+    location /health
+    {
+        access_log off;
+        return 200 "healthy\n";
+    }
+
 }


### PR DESCRIPTION
This PR adds a task to configure cronjobs to clear wps outputs.

It is using the ansible cron module:
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/cron_module.html

It adds two variables:
```
wps_cronjob_disabled: yes
wps_outputs_keep_days: 30
```

cronjobs are disabled by default.