### PR TITLE
update logrotate

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -29,6 +29,9 @@ logrotate_applications:
           - copytruncate
           - missingok
           - notifempty
+          - sharedscripts
+        postrotate:
+          - supervisorctl restart all
 
 # postgres
 db_install_postgresql: true

--- a/group_vars/all
+++ b/group_vars/all
@@ -32,7 +32,7 @@ logrotate_applications:
           - notifempty
           - sharedscripts
         postrotate:
-          - supervisorctl restart all
+          - supervisorctl restart all >/dev/null 2>/dev/null || true
 
 # postgres
 db_install_postgresql: true

--- a/group_vars/all
+++ b/group_vars/all
@@ -26,6 +26,7 @@ logrotate_applications:
         options:
           - rotate 7
           - daily
+          - dateext
           - copytruncate
           - missingok
           - notifempty


### PR DESCRIPTION
This PR adds a postscript to restart pywps after log rotation. PyWPS did not write to log file ... `truncate` also does not help.