### PR TITLE
Update cronjob

### DIFF
--- a/etc/cronjob_0pywps.sh
+++ b/etc/cronjob_0pywps.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# clean pywps outputs
-find /var/lib/pywps/outputs/rook/* -type d | xargs rm -rf
-

--- a/etc/rook_dkrz.yml
+++ b/etc/rook_dkrz.yml
@@ -7,6 +7,7 @@ wps_group: wps
 # enable cronjob to clean outputs
 wps_cronjob_disabled: no
 wps_outputs_keep_days: 3
+wps_temp_keep_days: 3
 # conda
 conda_env_use_spec: true
 conda_env_spec_file: spec-list.txt

--- a/etc/rook_dkrz.yml
+++ b/etc/rook_dkrz.yml
@@ -2,8 +2,14 @@
 wps_internal_hostname: cp4cds-cn1.dkrz.de
 # wps_external_hostname: cp4cds-cn1.dkrz.de
 wps_external_hostname: compute.mips.copernicus-climate.eu
+
+# user for pywps service
 wps_user: wps
 wps_group: wps
+## TODO: allow user wps to run cron
+# $ vim /etc/security/access.conf
+# + : wps : cron crond :0 tty1 tty2 tty3 tty4 tty5 tty6
+
 # enable cronjob to clean outputs
 wps_cronjob_disabled: no
 wps_outputs_keep_days: 3

--- a/group_vars/all
+++ b/group_vars/all
@@ -114,6 +114,7 @@ wps_basedir: "{{ service_user_home }}"
 wps_cache_dir: "{{ wps_basedir }}/cache"
 wps_cronjob_disabled: yes
 wps_outputs_keep_days: 30
+wps_temp_keep_days: 30
 wps_services: []
   # - name: emu
   #   repo: https://github.com/bird-house/emu.git

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -4,7 +4,7 @@
     name: "clear wps outputs"
     special_time: daily
     user: "{{ service_user }}"
-    job: 'find {{ wps_basedir }}/outputs/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -regextype sed -regex ".*/[a-f0-9\-]\{36\}$" -delete'
+    job: 'find {{ wps_basedir }}/outputs/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -regextype sed -regex ".*/[a-f0-9\-]\{36\}$" -exec rm -rf {} \;'
     cron_file: ansible_wps-clear-outputs
     disabled: "{{ wps_cronjob_disabled }}"
     state: present
@@ -24,7 +24,7 @@
     name: "clear wps tempfiles"
     special_time: daily
     user: "{{ service_user }}"
-    job: 'find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_temp_keep_days }} -name "pywps_process_*" -delete'
+    job: 'find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_temp_keep_days }} -name "pywps_process_*" -exec rm -rf {} \;'
     cron_file: ansible_wps-clear-tempfiles
     disabled: "{{ wps_cronjob_disabled }}"
     state: present

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -24,7 +24,7 @@
     name: "clear wps tempfiles"
     special_time: daily
     user: "{{ service_user }}"
-    job: 'find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -name "pywps_process_*" -delete'
+    job: 'find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_temp_keep_days }} -name "pywps_process_*" -delete'
     cron_file: ansible_wps-clear-tempfiles
     disabled: "{{ wps_cronjob_disabled }}"
     state: present

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -4,7 +4,17 @@
     name: "clear wps outputs"
     special_time: daily
     user: "{{ service_user }}"
-    job: "find {{ wps_basedir }}/outputs/* -maxdepth 1 -mtime +{{ wps_outputs_keep_days }} -exec rm -rf {} \\;"
+    job: 'find {{ wps_basedir }}/outputs/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -regextype sed -regex ".*/[a-f0-9\-]\{36\}$" -delete'
+    cron_file: ansible_wps-clear-outputs
+    disabled: "{{ wps_cronjob_disabled }}"
+    state: present
+
+- name: Clear wps status
+  cron:
+    name: "clear wps status"
+    special_time: daily
+    user: "{{ service_user }}"
+    job: 'find {{ wps_basedir }}/outputs/* -maxdepth 1 -type f -mtime +{{ wps_outputs_keep_days }} -regextype sed -regex ".*/[a-f0-9\-]\{36\}\.xml$" -delete'
     cron_file: ansible_wps-clear-outputs
     disabled: "{{ wps_cronjob_disabled }}"
     state: present
@@ -14,7 +24,7 @@
     name: "clear wps tempfiles"
     special_time: daily
     user: "{{ service_user }}"
-    job: "find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -exec rm -rf {} \\;"
+    job: "find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -name "pywps_process_*" -delete"
     cron_file: ansible_wps-clear-tempfiles
     disabled: "{{ wps_cronjob_disabled }}"
     state: present

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -24,7 +24,7 @@
     name: "clear wps tempfiles"
     special_time: daily
     user: "{{ service_user }}"
-    job: "find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -name "pywps_process_*" -delete"
+    job: 'find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -name "pywps_process_*" -delete'
     cron_file: ansible_wps-clear-tempfiles
     disabled: "{{ wps_cronjob_disabled }}"
     state: present

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -1,11 +1,21 @@
 ---
+- name: Clean up cron files managed by ansible
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - ansible_pywps
+    - ansible_wps-clear-outputs
+    - ansible_wps-clear-status
+    - ansible_wps-clear-tempfiles
+
 - name: Clear wps outputs
   cron:
     name: "clear wps outputs"
     special_time: daily
     user: "{{ service_user }}"
     job: 'find {{ wps_basedir }}/outputs/* -maxdepth 1 -type d -mtime +{{ wps_outputs_keep_days }} -regextype sed -regex ".*/[a-f0-9\-]\{36\}$" -exec rm -rf {} \;'
-    cron_file: ansible_wps-clear-outputs
+    cron_file: ansible_pywps
     disabled: "{{ wps_cronjob_disabled }}"
     state: present
 
@@ -15,7 +25,7 @@
     special_time: daily
     user: "{{ service_user }}"
     job: 'find {{ wps_basedir }}/outputs/* -maxdepth 1 -type f -mtime +{{ wps_outputs_keep_days }} -regextype sed -regex ".*/[a-f0-9\-]\{36\}\.xml$" -delete'
-    cron_file: ansible_wps-clear-status
+    cron_file: ansible_pywps
     disabled: "{{ wps_cronjob_disabled }}"
     state: present
 
@@ -25,6 +35,6 @@
     special_time: daily
     user: "{{ service_user }}"
     job: 'find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_temp_keep_days }} -name "pywps_process_*" -exec rm -rf {} \;'
-    cron_file: ansible_wps-clear-tempfiles
+    cron_file: ansible_pywps
     disabled: "{{ wps_cronjob_disabled }}"
     state: present

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -15,7 +15,7 @@
     special_time: daily
     user: "{{ service_user }}"
     job: 'find {{ wps_basedir }}/outputs/* -maxdepth 1 -type f -mtime +{{ wps_outputs_keep_days }} -regextype sed -regex ".*/[a-f0-9\-]\{36\}\.xml$" -delete'
-    cron_file: ansible_wps-clear-outputs
+    cron_file: ansible_wps-clear-status
     disabled: "{{ wps_cronjob_disabled }}"
     state: present
 

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -1,7 +1,7 @@
 ---
 - name: Clean up cron files managed by ansible
   file:
-    path: "{{ item }}"
+    path: "/etc/cron.d/{{ item }}"
     state: absent
   with_items:
     - ansible_pywps


### PR DESCRIPTION
This PR updates the cronjobs managed by ansible for pywps. 

Changes:
* All cronjobs are written to `/etc/cron.d/ansible_pywps`.
* using regex to match the output names (uuid).
* Added clean script to remove pywps cronfile before updating cronjobs.