### PR TITLE
Clean gunicorn procs

### DIFF
--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -47,14 +47,16 @@
     src: ./templates/restart-pywps.sh.j2
     dest: "{{ service_user_home }}/restart-pywps.sh"
 
-- name: Restart pywps and clean out old gunicorn processes every night
+- name: Restart pywps service and clean out old gunicorn processes every night
   cron:
     name: "restart pywps"
     # weekday: "0"
     minute: "0"
     hour: "3"
     user: "{{ service_user }}"
-    job: "{{ service_user_home }}/restart-pywps.sh 2>&1 > /var/log/pywps/restart-pywps.log"
+    job: "{{ service_user_home }}/restart-pywps.sh {{ item.name }} 2>&1 > /var/log/pywps/restart-{{ item.name }}.log"
     cron_file: ansible_pywps
     disabled: "{{ cron_disabled }}"
     state: present
+  with_items:
+    - "{{ wps_services }}"

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -46,6 +46,8 @@
   template:
     src: ./templates/restart-pywps.sh.j2
     dest: "{{ service_user_home }}/restart-pywps.sh"
+    owner: "{{ service_user }}"
+    mode: 0744
 
 - name: Restart pywps service and clean out old gunicorn processes every night
   cron:

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -46,7 +46,8 @@
   template:
     src: ./templates/restart-pywps.sh.j2
     dest: "{{ service_user_home }}/restart-pywps.sh"
-    owner: "{{ service_user }}"
+    # owner: "{{ service_user }}"
+    owner: root
     mode: 0744
 
 - name: Restart pywps service and clean out old gunicorn processes every night
@@ -55,7 +56,8 @@
     # weekday: "0"
     minute: "0"
     hour: "3"
-    user: "{{ service_user }}"
+    # user: "{{ service_user }}"
+    user: root
     job: "{{ service_user_home }}/restart-pywps.sh {{ item.name }} 2>&1 > /var/log/pywps/restart-{{ item.name }}.log"
     cron_file: ansible_pywps
     disabled: "{{ cron_disabled }}"

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -5,9 +5,6 @@
     state: absent
   with_items:
     - ansible_pywps
-    - ansible_wps-clear-outputs
-    - ansible_wps-clear-status
-    - ansible_wps-clear-tempfiles
 
 - name: Add MAILTO to cron file
   community.general.cronvar:
@@ -41,6 +38,23 @@
     special_time: daily
     user: "{{ service_user }}"
     job: 'find {{ wps_basedir }}/tmp/* -maxdepth 1 -type d -mtime +{{ wps_temp_keep_days }} -name "pywps_process_*" -exec rm -rf {} \;'
+    cron_file: ansible_pywps
+    disabled: "{{ cron_disabled }}"
+    state: present
+
+- name: Copy restart script
+  template:
+    src: ./templates/restart-pywps.sh.j2
+    dest: "{{ service_user_home }}/restart-pywps.sh"
+
+- name: Restart pywps and clean out old gunicorn processes every night
+  cron:
+    name: "restart pywps"
+    # weekday: "0"
+    minute: "0"
+    hour: "3"
+    user: "{{ service_user }}"
+    job: "{{ service_user_home }}/restart-pywps.sh 2>&1 > /var/log/pywps/restart-pywps.log"
     cron_file: ansible_pywps
     disabled: "{{ cron_disabled }}"
     state: present

--- a/roles/pywps/templates/restart-pywps.sh.j2
+++ b/roles/pywps/templates/restart-pywps.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Restart pywps service and clean out old gunicorn processes
+APP=rook
+echo "[INFO] Stopping $APP"
+supervisorctl stop $APP
+sleep 1
+echo "[INFO] Finding gunicorn processes..."
+gunicorn_pids=$(echo $(ps aux | grep -i gunicorn | grep $APP | cut -c10-15))
+echo "[INFO] Found processes: $gunicorn_pids"
+if [ "$gunicorn_pids" ]; then
+    echo "[WARN] Killing processes: $gunicorn_pids"
+    kill $gunicorn_pids
+fi
+supervisorctl start $APP
+echo "[INFO] Restarted $APP"

--- a/roles/pywps/templates/restart-pywps.sh.j2
+++ b/roles/pywps/templates/restart-pywps.sh.j2
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 # Restart pywps service and clean out old gunicorn processes
+# Usage: restart-pywps [service_name]
+# Example: restart-pywps rook
+
 APP="$1"
 echo "[INFO] Stopping $APP"
 supervisorctl stop $APP

--- a/roles/pywps/templates/restart-pywps.sh.j2
+++ b/roles/pywps/templates/restart-pywps.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Restart pywps service and clean out old gunicorn processes
-APP=rook
+APP="$1"
 echo "[INFO] Stopping $APP"
 supervisorctl stop $APP
 sleep 1


### PR DESCRIPTION
This PR adds a cronjob to restart pywps. This is necessary to clean gunicorn processes.