### PR TITLE
nginx access control

### DIFF
--- a/etc/rook_dkrz.yml
+++ b/etc/rook_dkrz.yml
@@ -24,6 +24,10 @@ db_install_postgresql: false
 db_install_sqlite: true
 db_user: pywps
 db_password: pywps
+# access control
+wps_enable_acl: true
+wps_acl_allow:
+   - 136.172.0.0/16
 # roocs
 roocs_enabled: true
 roocs_site: dkrz

--- a/etc/sample-rook.yml
+++ b/etc/sample-rook.yml
@@ -7,8 +7,13 @@ db_install_sqlite: true
 #db_password: dbuser
 cron_mailto: root
 wps_enable_https: false
+# access control
+wps_enable_acl: false
+wps_acl_allow:
+  - 192.168.128.1/24
 # roocs
 roocs_enabled: true
+roocs_site: demo
 roocs_demo_data_dir: /vagrant/.local/data
 wps_services:
   - name: rook

--- a/group_vars/all
+++ b/group_vars/all
@@ -115,6 +115,8 @@ roocs_cache_dir: "/tmp/inventory_cache"
 wps_user: "{{ service_user }}"
 wps_group: "{{ service_group }}"
 wps_enable_https: false
+wps_enable_acl: false
+wps_acl_allow: []
 wps_run_dir: /run/pywps
 wps_database: "postgresql+psycopg2://{{ db_user }}:{{ db_password }}@{{ db_host }}:{{ db_port }}/pywps"
 wps_webservice_enabled: true

--- a/roles/pywps/templates/nginx.conf.j2
+++ b/roles/pywps/templates/nginx.conf.j2
@@ -14,6 +14,15 @@ map $arg_request $wps_nocache {
   Execute         1;
 }
 
+{% if wps_enable_acl %}
+map $arg_request $wps_deny {
+  default         1;
+  GetCapabilities 0;
+  DescribeProcess 0;
+  Execute         1;
+}
+{% endif %}
+
 server {
     {% if wps_enable_https %}
     listen                 {{ item.port | default('5000') }} ssl;
@@ -50,6 +59,18 @@ server {
         proxy_buffering         on;
         client_max_body_size    8m;
         proxy_read_timeout      60s;
+        {% if wps_enable_acl %}
+        # access control
+        limit_except GET {
+            {% for ip_range in wps_acl_allow %}
+            allow {{ ip_range }};
+            {% endfor %}
+            deny all;
+        }
+        if ($wps_deny) {
+            return 403;
+        }
+        {% endif %}
     }
 
     {% if not fs_enabled %}


### PR DESCRIPTION
This PR adds optional access control with nginx config. The execution of a wps process can be restricted to specific IP ranges:
```
# access control
wps_enable_acl: true
wps_acl_allow:
  - 192.168.128.1/24
 ```