### PR TITLE
Gunicorn config

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -84,7 +84,7 @@ nginx_extra_http_options: |
 # gunicorn
 # https://docs.gunicorn.org/en/stable/settings.html
 gunicorn_workers: 5  # rule of thumb: 2 * CPUs + 1
-gunicorn_worker_class: 'sync'  # or async, needs gevent
+gunicorn_worker_class: 'sync'  # or "gevent", needs gevent
 
 # postgres
 postgresql_databases:

--- a/group_vars/all
+++ b/group_vars/all
@@ -81,6 +81,11 @@ nginx_extra_http_options: |
     application/ncML+xml    ncml;
   }
 
+# gunicorn
+# https://docs.gunicorn.org/en/stable/settings.html
+gunicorn_workers: 5  # rule of thumb: 2 * CPUs + 1
+gunicorn_worker_class: 'sync'  # or async, needs gevent
+
 # postgres
 postgresql_databases:
   - name:  "pywps"

--- a/roles/pywps/tasks/conda.yml
+++ b/roles/pywps/tasks/conda.yml
@@ -40,7 +40,7 @@
     - conda
 
 - name: Install additional pip packages.
-  command: "{{ conda_envs_dir}}/{{ item.name }}/bin/pip install gunicorn psycopg2-binary drmaa dill sphinx pytest"
+  command: "{{ conda_envs_dir}}/{{ item.name }}/bin/pip install gunicorn[gevent] psycopg2-binary drmaa dill pytest"
   with_items: "{{ wps_services }}"
   when: conda_env.changed or conda_env_spec.changed
   tags:

--- a/roles/pywps/templates/gunicorn.py.j2
+++ b/roles/pywps/templates/gunicorn.py.j2
@@ -1,6 +1,6 @@
 bind = 'unix://{{ wps_run_dir }}/{{ item.name }}.sock'
-workers = 3
-worker_class = 'sync'
+workers = {{ gunicorn_workers }}
+worker_class = '{{ gunicorn_worker_class }}'
 
 # environment
 raw_env = [


### PR DESCRIPTION
This PR makes gunicorn workers configurable:

https://docs.gunicorn.org/en/stable/settings.html
```
gunicorn_workers: 5  # rule of thumb: 2 * CPUs + 1
gunicorn_worker_class: 'sync'  # or "gevent", needs gevent
```

`sync` is default. One can also choose `gevent`. `gevent` is installed in the conda environment.