### PR TITLE
Fix conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ tests/test.sh
 
 # CEDA submodule for local modifcations
 ansible-birdhouse-content
+
+# macos
+.DS_Store

--- a/group_vars/all
+++ b/group_vars/all
@@ -45,9 +45,15 @@ slurm_partitions:
     Nodes: localhost
 slurm_munge_key: /etc/munge/munge.key
 
-# miniconda
+# miniconda: we need to use Miniforge!
 miniconda_parent_dir: "{{ prefix }}"
 miniconda_make_sys_default: False
+#url: https://github.com/conda-forge/miniforge/releases/download/24.9.2-0/Miniforge3-24.9.2-0-Linux-x86_64.sh
+miniconda_ver: 24.9.2-0
+miniconda_mirror: https://github.com/conda-forge/miniforge/releases/download
+miniconda_name: 'Miniforge3-{{ miniconda_ver }}-{{ miniconda_platform }}'
+miniconda_installer_url: '{{ miniconda_mirror }}/{{ miniconda_ver }}/{{ miniconda_installer_sh }}'
+miniconda_checksum: sha256:ca8c544254c40ae5192eb7db4e133ff4eb9f942a1fec737dba8205ac3f626322
 
 # conda
 conda_location: "{{ prefix }}/anaconda"

--- a/roles/pywps/tasks/conda.yml
+++ b/roles/pywps/tasks/conda.yml
@@ -40,7 +40,7 @@
     - conda
 
 - name: Install additional pip packages.
-  command: "{{ conda_envs_dir}}/{{ item.name }}/bin/pip install gunicorn[gevent] psycopg2-binary drmaa dill pytest"
+  command: "{{ conda_envs_dir}}/{{ item.name }}/bin/pip install gunicorn[gevent] psycopg2-binary drmaa dill pytest pytest-cov"
   with_items: "{{ wps_services }}"
   when: conda_env.changed or conda_env_spec.changed
   tags:


### PR DESCRIPTION
This PR updates the config for miniconda installation. We need to install conda from conda-forge:
https://github.com/conda-forge/miniforge

This PR also adds `pytest-cov` to the post-installation to run smoke tests.