### PR TITLE
using extra_vars.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ quick: roles
 .PHONY: play
 play: roles
 	echo "Installing PyWPS application with Ansible [all tasks] ..."
-	ansible-playbook -c local -i hosts playbook.yml
+	ansible-playbook -c local -i hosts playbook.yml --extra-vars "@extra_vars.yml"
 
 .PHONY: clean
 clean:

--- a/extra_vars.yml
+++ b/extra_vars.yml
@@ -1,0 +1,7 @@
+# Using miniforge! need to overwrite vars in miniconda role.
+# url: https://github.com/conda-forge/miniforge/releases/download/24.9.2-0/Miniforge3-24.9.2-0-Linux-x86_64.sh
+miniconda_ver: 24.9.2-0
+miniconda_mirror: https://github.com/conda-forge/miniforge/releases/download
+miniconda_name: 'Miniforge3-{{ miniconda_ver }}-{{ miniconda_platform }}'
+miniconda_installer_url: '{{ miniconda_mirror }}/{{ miniconda_ver }}/{{ miniconda_installer_sh }}'
+miniconda_checksum: sha256:ca8c544254c40ae5192eb7db4e133ff4eb9f942a1fec737dba8205ac3f626322

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -45,15 +45,9 @@ slurm_partitions:
     Nodes: localhost
 slurm_munge_key: /etc/munge/munge.key
 
-# miniconda: we need to use Miniforge!
+# miniconda: we need to use Miniforge! See extra_vars.yml
 miniconda_parent_dir: "{{ prefix }}"
 miniconda_make_sys_default: False
-#url: https://github.com/conda-forge/miniforge/releases/download/24.9.2-0/Miniforge3-24.9.2-0-Linux-x86_64.sh
-miniconda_ver: 24.9.2-0
-miniconda_mirror: https://github.com/conda-forge/miniforge/releases/download
-miniconda_name: 'Miniforge3-{{ miniconda_ver }}-{{ miniconda_platform }}'
-miniconda_installer_url: '{{ miniconda_mirror }}/{{ miniconda_ver }}/{{ miniconda_installer_sh }}'
-miniconda_checksum: sha256:ca8c544254c40ae5192eb7db4e133ff4eb9f942a1fec737dba8205ac3f626322
 
 # conda
 conda_location: "{{ prefix }}/anaconda"

--- a/playbook.yml
+++ b/playbook.yml
@@ -13,6 +13,9 @@
     # - name: "Ansible | List all known variables and facts"
     #   debug:
     #     var: hostvars['192.168.50.44']
+    - name: Debug miniconda url
+      debug:
+        var: miniconda_installer_url
   roles:
     - common
     - role: andrewrothstein.miniconda


### PR DESCRIPTION
This PR uses `extra_vars.yml` to overwrite variables of the miniconda role.

This is necessary because we can't use miniconda anymore and need to dowload miniforge.