### PR TITLE
added role community.postgresql

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -8,4 +8,5 @@ roles:
 
 collections:
   - name: community.general
+  - name: community.postgresql
   - name: ansible.posix


### PR DESCRIPTION
This PR adds the collection: `community.postgresql` 

This is necessary for the latest ansible version.