### PR TITLE
added archive for failed jobs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,9 +15,10 @@ Changes:
 - enforce a configurable native Slurm partition timeout and add optional
   read-only `squeue`/`sinfo` monitoring for queue pressure, long-running jobs,
   scheduler capacity, and a health-check red-alert file
-- express PyWPS stale-request thresholds in minutes and run Slurm monitoring,
-  XML/database recovery, and polling recovery on staggered five-minute
-  schedules, while retaining hourly job statistics
+- express PyWPS stale-request thresholds in minutes, run monitoring and ordered
+  recovery on a five-minute cadence, and retain hourly job statistics
+- preserve failed and recovery-generated PyWPS status documents in a
+  searchable, per-service 30-day incident archive with UTC filenames
 
 ## 0.9.0 (2026-07-31)
 

--- a/README.md
+++ b/README.md
@@ -301,9 +301,9 @@ ln -s etc/custom-production.yml custom.yml
 
 ### Configure output and temporary-file retention
 
-When the cleanup cron jobs are enabled, they run hourly and remove PyWPS
-outputs and temporary process directories older than 12 hours. Enable the
-jobs and configure their retention periods with:
+When the cleanup cron jobs are enabled, they run hourly at minute 3 and remove
+PyWPS outputs and temporary process directories older than 12 hours. Enable
+the jobs and configure their retention periods with:
 
 ```yaml
 cron_enabled: true
@@ -349,13 +349,18 @@ pywps_job_control_recovery_schedule:
   hour: "*"
 pywps_job_control_stale_after_minutes: 120
 pywps_job_control_recovery_limit: 100
+pywps_job_incident_archive_enabled: true
+pywps_job_incident_keep_days: 30
 pywps_job_control_layers:
   - xml
   - database
 ```
 
-The read-only monitor runs every five minutes. When recovery is enabled, XML
-and database recovery runs every five minutes with a one-minute offset.
+The monitor runs every five minutes. It does not change live request state,
+but it preserves failed XML documents in the incident archive. When recovery
+is enabled, one locked recovery command runs every five minutes with a
+one-minute offset. It always processes XML, database, and then polling evidence;
+disabled polling recovery is skipped within that ordered run.
 Standard cron fields
 `minute`, `hour`, `day`, `month`, and `weekday` are configurable. When the XML
 layer and scheduled output cleanup are enabled, the stale threshold must be
@@ -370,6 +375,8 @@ monitor_enabled = true
 recovery_enabled = false
 missing_status_recovery_enabled = false
 statistics_enabled = true
+incident_archive_enabled = true
+incident_archive_dir = /var/lib/pywps/job-incidents/SERVICE_NAME
 ```
 
 The cron entries are controlled globally by `cron_enabled`; when invoked, the
@@ -384,7 +391,7 @@ last database status time, falling back to the request start time. Timestamps
 with `Z`, and database timestamps without an offset, are interpreted as UTC;
 the deployment host should therefore keep its clock and timezone consistent.
 
-Monitoring never changes state. Review
+Monitoring never changes live request state. Review
 `/var/log/pywps/SERVICE_NAME-job-monitor.log` before enabling scheduled
 recovery, or run the appropriate recovery shortcut manually.
 This path is derived from the service's existing `[logging] file` setting.
@@ -450,8 +457,38 @@ batches bounded even when years of unfinished requests have accumulated.
 Recovery defaults to `pywps_job_control_recovery_limit`, which is 100. Monitoring
 remains unlimited unless `--limit` is explicitly supplied, so an old backlog
 cannot hide newer stalled requests. An explicit `--limit` overrides the
-configured recovery default. The underlying `--status-counts` option enables a
-complete database aggregate for explicit low-level invocations.
+configured recovery defaults for every selected layer. Polling recovery uses
+its separate default of `pywps_missing_status_recovery_limit`, which is 20.
+The underlying `--status-counts` option enables a complete database aggregate
+for explicit low-level invocations.
+
+### Preserve failed-job evidence
+
+Failed PyWPS status documents are copied into a separate, bounded archive
+before routine output cleanup can remove them:
+
+```yaml
+pywps_job_incident_archive_enabled: true
+pywps_job_incident_archive_dir: /var/lib/pywps/job-incidents
+pywps_job_incident_keep_days: 30
+```
+
+Each service has its own subdirectory. Files use UTC timestamps and searchable
+names such as
+`20260807T142530Z__error__rook__subset__UUID.xml`. Failures created by the
+recovery layers use `recovered` instead of `error`. The complete status
+document is preserved, including the process identifier, submitted inputs,
+and failure message. Archive creation is atomic and idempotent; an existing
+incident is never overwritten. The job-control log records the incident type
+and archive path.
+
+The archive cleanup runs hourly at minute 3 and removes incident XML older than
+30 days by default. Ordinary successful status documents retain the shorter
+`wps_outputs_keep_hours` period. Inspect incidents with, for example:
+
+```sh
+sudo find /var/lib/pywps/job-incidents/rook -type f -name '*.xml' -print
+```
 
 Slurm timeout enforcement and host-wide queue monitoring are described under
 [Use the Slurm scheduler](#use-the-slurm-scheduler).
@@ -484,18 +521,15 @@ sudo /var/lib/pywps/statistics SERVICE_NAME
 
 ### Recover repeatedly polled missing status documents
 
-An independent, opt-in cron job can inspect recent Nginx access logs for WPS
+The ordered, opt-in recovery run can inspect recent Nginx access logs for WPS
 clients repeatedly polling a status URL that returns `404`. Once the same valid
-UUID has reached the configured request count and polling duration, the job creates
+UUID has reached the configured request count and polling duration, it creates
 a WPS 1.0 `ProcessFailed` status document so clients such as OWSLib can finish
 instead of polling forever.
 
 ```yaml
 pywps_job_control_recovery_enabled: true
 pywps_missing_status_recovery_enabled: true
-pywps_missing_status_recovery_schedule:
-  minute: "2-57/5"
-  hour: "*"
 pywps_missing_status_poll_window_minutes: 60
 pywps_missing_status_min_poll_count: 3
 pywps_missing_status_min_poll_duration_minutes: 15
@@ -504,9 +538,10 @@ pywps_missing_status_access_log: /var/log/nginx/access.log
 pywps_missing_status_database_guard: true
 ```
 
-The default schedule runs every five minutes, offset from the main monitor by
-two minutes, and considers only requests from the preceding hour. Recovery
-requires at least three `GET` or `HEAD` responses
+The default recovery schedule runs every five minutes at minute 1 and considers
+only requests from the preceding hour. Polling is the last recovery layer, so
+XML and database reconciliation has already completed in the same locked run.
+Recovery requires at least three `GET` or `HEAD` responses
 with status `404`, spanning at least 15 minutes rather than arriving in one
 short burst. Only the exact output path configured for that PyWPS service and a
 syntactically valid UUID filename are accepted. Only the configured active log
@@ -514,8 +549,8 @@ is inspected. Rotated logs are intentionally ignored: persistent polling
 appears in the active log again and qualifies after the configured minimum
 duration.
 
-On a VM hosting multiple PyWPS services, Ansible creates one recovery cron
-entry per service. Each entry uses that service's `/etc/pywps/SERVICE.cfg`,
+On a VM hosting multiple PyWPS services, Ansible creates one ordered recovery
+cron entry per service. Each entry uses that service's `/etc/pywps/SERVICE.cfg`,
 filters the shared Nginx log to its exact configured output URL path, and writes
 only to its configured output directory.
 

--- a/TODO.md
+++ b/TODO.md
@@ -46,10 +46,6 @@ by the PyWPS deployment.
   specifications during the longer PyWPS environment update. In particular,
   retain the Conda-linked `psycopg2` build: the pip `psycopg2-binary` wheel's
   bundled libraries segfaulted on a fresh Python 3.13 connection.
-- Add a persistent, bounded incident history for stalled, failed, timed-out,
-  and recovered jobs. Record the request UUID, Slurm job ID when available,
-  timestamps, state or reason, and recovery action and result, and provide a
-  simple way for administrators to inspect it.
 - Consolidate and clean up the monitoring and recovery scripts after further
   production validation. Normalize locking, scheduling, batch limits, logging,
   and exit status handling, and remove obsolete compatibility paths.

--- a/etc/sample-production.yml
+++ b/etc/sample-production.yml
@@ -35,15 +35,16 @@ pywps_job_control_recovery_schedule:
 pywps_job_control_stale_after_minutes: 120
 # Maximum recovered jobs per layer.
 pywps_job_control_recovery_limit: 100
+# Preserve failed status XML for later investigation.
+pywps_job_incident_archive_enabled: true
+pywps_job_incident_archive_dir: /var/lib/pywps/job-incidents
+pywps_job_incident_keep_days: 30
 # Layers used when a command does not specify --layer.
 pywps_job_control_layers:
   - xml
   - database
 # Create failure XML for repeated Nginx 404 status polling.
 pywps_missing_status_recovery_enabled: false
-pywps_missing_status_recovery_schedule:
-  minute: "2-57/5"
-  hour: "*"
 pywps_missing_status_poll_window_minutes: 60
 pywps_missing_status_min_poll_count: 3
 pywps_missing_status_min_poll_duration_minutes: 15

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -209,18 +209,17 @@ pywps_job_control_recovery_schedule:
 pywps_job_control_stale_after_minutes: 120
 # Maximum recovered jobs per layer.
 pywps_job_control_recovery_limit: 100
+# Preserve failed status documents separately from routine output cleanup.
+pywps_job_incident_archive_enabled: true
+pywps_job_incident_archive_dir: "{{ service_user_home }}/job-incidents"
+pywps_job_incident_keep_days: 30
+pywps_job_incident_keep_minutes: "{{ (pywps_job_incident_keep_days | int) * 1440 }}"
 # Layers used when a command does not specify --layer.
 pywps_job_control_layers:
   - xml
   - database
 # Create failure XML for repeated Nginx 404 status polling.
 pywps_missing_status_recovery_enabled: false
-pywps_missing_status_recovery_schedule:
-  minute: "2-57/5"
-  hour: "*"
-  day: "*"
-  month: "*"
-  weekday: "*"
 pywps_missing_status_poll_window_minutes: 60
 pywps_missing_status_min_poll_count: 3
 pywps_missing_status_min_poll_duration_minutes: 15

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -8,7 +8,8 @@
 - name: Clear PyWPS output directories
   ansible.builtin.cron:
     name: "clear wps outputs"
-    special_time: hourly
+    minute: "3"
+    hour: "*"
     user: "{{ cron_user }}"
     job: >-
       find {{ wps_basedir }}/outputs -mindepth 2 -maxdepth 2
@@ -23,7 +24,8 @@
 - name: Clear PyWPS status documents
   ansible.builtin.cron:
     name: "clear wps status"
-    special_time: hourly
+    minute: "3"
+    hour: "*"
     user: "{{ cron_user }}"
     job: >-
       find {{ wps_basedir }}/outputs -mindepth 2 -maxdepth 2
@@ -37,7 +39,8 @@
 - name: Clear PyWPS temporary process directories
   ansible.builtin.cron:
     name: "clear wps tempfiles"
-    special_time: hourly
+    minute: "3"
+    hour: "*"
     user: "{{ cron_user }}"
     job: >-
       find {{ wps_basedir }}/tmp -mindepth 2 -maxdepth 2
@@ -64,9 +67,11 @@
       - pywps_job_statistics_schedule | type_debug == 'dict'
       - pywps_job_control_stale_after_minutes | float > 0
       - pywps_job_control_recovery_limit | int > 0
+      - pywps_job_incident_keep_days | int > 0
+      - pywps_job_incident_keep_minutes | int > 0
+      - pywps_job_incident_archive_dir | length > 0
       - pywps_job_control_layers | length > 0
       - pywps_job_control_layers | difference(['xml', 'database', 'polling']) | length == 0
-      - pywps_missing_status_recovery_schedule | type_debug == 'dict'
       - pywps_missing_status_poll_window_minutes | float > 0
       - pywps_missing_status_min_poll_count | int > 0
       - pywps_missing_status_min_poll_duration_minutes | float >= 0
@@ -83,9 +88,9 @@
       The job-control schedule must be a cron-field mapping, age must be
       positive and shorter than output retention for scheduled XML checks,
       recovery limit must be positive, and layers must contain xml, database,
-      or polling. Missing-status recovery also requires a valid schedule,
-      positive polling window, poll count and recovery limit, and a minimum
-      poll duration shorter than its polling window.
+      or polling. Incident retention must be positive. Missing-status recovery
+      also requires a positive polling window, poll count and recovery limit,
+      and a minimum poll duration shorter than its polling window.
 
 - name: Install PyWPS job-control script
   ansible.builtin.copy:
@@ -94,6 +99,41 @@
     owner: root
     group: root
     mode: "0755"
+
+- name: Create PyWPS job-incident archive base directory
+  ansible.builtin.file:
+    path: "{{ pywps_job_incident_archive_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  when: pywps_job_incident_archive_enabled | bool
+
+- name: Create per-service PyWPS job-incident archive directories
+  ansible.builtin.file:
+    path: "{{ pywps_job_incident_archive_dir }}/{{ item.name }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+  loop: "{{ wps_services }}"
+  when: pywps_job_incident_archive_enabled | bool
+
+- name: Clean up expired PyWPS job incidents
+  ansible.builtin.cron:
+    name: "clear archived PyWPS job incidents"
+    minute: "3"
+    hour: "*"
+    user: "{{ cron_user }}"
+    job: >-
+      find {{ pywps_job_incident_archive_dir }} -mindepth 2 -maxdepth 2
+      -ignore_readdir_race -type f -name "*.xml"
+      -mmin +{{ pywps_job_incident_keep_minutes }} -delete
+    cron_file: ansible_pywps
+    disabled: >-
+      {{ (cron_disabled | bool)
+         or not (pywps_job_incident_archive_enabled | bool) }}
+    state: present
 
 - name: Validate Slurm timeout and monitoring settings
   ansible.builtin.assert:
@@ -235,7 +275,7 @@
     state: present
   loop: "{{ wps_services }}"
 
-- name: Schedule recovery of stalled PyWPS XML and database jobs
+- name: Schedule ordered PyWPS job recovery
   ansible.builtin.cron:
     name: "recover stalled PyWPS jobs for {{ item.name }}"
     minute: "{{ pywps_job_control_recovery_schedule.minute | default('1-56/5') }}"
@@ -248,8 +288,7 @@
       {{ conda_envs_dir }}/{{ item.name }}/bin/python
       {{ cron_script_dir }}/pywps-job-control.py
       --config /etc/pywps/{{ item.name }}.cfg recover
-      --layer xml --layer database
-      --limit {{ pywps_job_control_recovery_limit }}
+      --layer xml --layer database --layer polling
     cron_file: ansible_pywps
     disabled: >-
       {{ (cron_disabled | bool)
@@ -257,27 +296,12 @@
     state: present
   loop: "{{ wps_services }}"
 
-- name: Schedule recovery of repeatedly polled missing PyWPS status documents
+- name: Remove separate missing-status recovery schedule
   ansible.builtin.cron:
     name: "recover missing pywps status documents for {{ item.name }}"
-    minute: "{{ pywps_missing_status_recovery_schedule.minute | default('2-57/5') }}"
-    hour: "{{ pywps_missing_status_recovery_schedule.hour | default('*') }}"
-    day: "{{ pywps_missing_status_recovery_schedule.day | default('*') }}"
-    month: "{{ pywps_missing_status_recovery_schedule.month | default('*') }}"
-    weekday: "{{ pywps_missing_status_recovery_schedule.weekday | default('*') }}"
     user: root
-    job: >-
-      {{ conda_envs_dir }}/{{ item.name }}/bin/python
-      {{ cron_script_dir }}/pywps-job-control.py
-      --config /etc/pywps/{{ item.name }}.cfg recover
-      --layer polling
-      --limit {{ pywps_missing_status_recovery_limit }}
     cron_file: ansible_pywps
-    disabled: >-
-      {{ (cron_disabled | bool)
-         or not (pywps_job_control_recovery_enabled | bool)
-         or not (pywps_missing_status_recovery_enabled | bool) }}
-    state: present
+    state: absent
   loop: "{{ wps_services }}"
 
 - name: Remove obsolete daily PyWPS statistics cron entries

--- a/roles/pywps/templates/pywps.cfg.j2
+++ b/roles/pywps/templates/pywps.cfg.j2
@@ -65,11 +65,14 @@ statistics_enabled = {{ pywps_job_statistics_enabled | bool | lower }}
 layers = {{ pywps_job_control_layers | join(',') }}
 stale_after_minutes = {{ pywps_job_control_stale_after_minutes }}
 recovery_limit = {{ pywps_job_control_recovery_limit }}
+incident_archive_enabled = {{ pywps_job_incident_archive_enabled | bool | lower }}
+incident_archive_dir = {{ pywps_job_incident_archive_dir }}/{{ item.name }}
 lock_file = /run/lock/pywps-job-control-{{ item.name }}.lock
 access_log = {{ pywps_missing_status_access_log }}
 poll_window_minutes = {{ pywps_missing_status_poll_window_minutes }}
 min_poll_count = {{ pywps_missing_status_min_poll_count }}
 min_poll_duration_minutes = {{ pywps_missing_status_min_poll_duration_minutes }}
+missing_status_recovery_limit = {{ pywps_missing_status_recovery_limit }}
 missing_status_database_guard = {{ pywps_missing_status_database_guard | bool | lower }}
 
 {% if item.extra_config is defined %}

--- a/scripts/pywps-job-control.py
+++ b/scripts/pywps-job-control.py
@@ -13,7 +13,7 @@ import re
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterable
@@ -66,6 +66,10 @@ class Settings:
     missing_status_recovery_enabled: bool = False
     statistics_enabled: bool = True
     service_name: str = "unknown"
+    incident_archive_enabled: bool = False
+    incident_archive_dir: Path | None = None
+    recovery_limit: int = 100
+    missing_status_recovery_limit: int = 20
 
 
 @dataclass
@@ -107,6 +111,8 @@ class XmlStatus:
     modification_time: datetime
     source_identity: tuple[int, int, int, int]
     namespaces: list[tuple[str, str]]
+    process_identifier: str
+    contents: bytes
 
     @property
     def last_update(self) -> datetime:
@@ -183,6 +189,18 @@ def read_xml_status(path: Path) -> tuple[XmlStatus, ET.ElementTree]:
     states = [child for child in list(status) if local_name(child.tag).startswith("Process")]
     if len(states) != 1:
         raise ValueError("Status must contain exactly one process state")
+    process = next(
+        (element for element in root.iter() if local_name(element.tag) == "Process"),
+        None,
+    )
+    identifier = next(
+        (
+            element.text.strip()
+            for element in process.iter()
+            if local_name(element.tag) == "Identifier" and element.text
+        ),
+        "unknown",
+    ) if process is not None else "unknown"
 
     return (
         XmlStatus(
@@ -193,9 +211,78 @@ def read_xml_status(path: Path) -> tuple[XmlStatus, ET.ElementTree]:
             modification_time=datetime.fromtimestamp(path_stat.st_mtime, UTC),
             source_identity=stat_identity(path_stat),
             namespaces=namespaces,
+            process_identifier=identifier,
+            contents=contents,
         ),
         tree,
     )
+
+
+def safe_filename_component(value: str, fallback: str = "unknown") -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-.")
+    return (sanitized or fallback)[:80]
+
+
+def failure_incident_kind(tree: ET.ElementTree) -> str:
+    messages = " ".join(
+        element.text or ""
+        for element in tree.getroot().iter()
+        if local_name(element.tag) == "ExceptionText"
+    )
+    if "stalled-job recovery" in messages or "repeated polling" in messages:
+        return "recovered"
+    return "error"
+
+
+def archive_failed_xml(
+    document: XmlStatus,
+    tree: ET.ElementTree,
+    settings: Settings,
+    logger: logging.Logger,
+) -> Path | None:
+    if not settings.incident_archive_enabled:
+        return None
+    if settings.incident_archive_dir is None:
+        raise ValueError("incident archiving requires incident_archive_dir")
+    if document.state != "ProcessFailed":
+        raise ValueError("only failed status documents can be archived")
+    if stat_identity(document.path.stat()) != document.source_identity:
+        raise RuntimeError("status file changed before incident archiving")
+
+    archive_dir = settings.incident_archive_dir
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = document.creation_time.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+    kind = failure_incident_kind(tree)
+    service = safe_filename_component(settings.service_name)
+    process = safe_filename_component(document.process_identifier)
+    destination = archive_dir / (
+        f"{timestamp}__{kind}__{service}__{process}__{document.job_uuid}.xml"
+    )
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{document.job_uuid}.", suffix=".tmp", dir=archive_dir
+    )
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(document.contents)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary_name, 0o640)
+        try:
+            os.link(temporary_name, destination)
+        except FileExistsError:
+            return destination
+    finally:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+    logger.info(
+        "layer=xml job=%s status=failed incident=%s archive=%s result=created",
+        document.job_uuid,
+        kind,
+        destination,
+    )
+    return destination
 
 
 def find_status_files(output_dir: Path) -> Iterable[Path]:
@@ -293,6 +380,8 @@ def run_xml_layer(
         try:
             document, tree = read_xml_status(path)
             if document.state in FINAL_XML_STATES:
+                if document.state == "ProcessFailed":
+                    archive_failed_xml(document, tree, settings, logger)
                 logger.debug(
                     "layer=xml job=%s status=%s finding=final",
                     document.job_uuid,
@@ -321,6 +410,8 @@ def run_xml_layer(
                     f"for at least {settings.stale_after_minutes:g} minutes."
                 )
                 write_failed_xml(document, tree, message, now)
+                recovered_document, recovered_tree = read_xml_status(path)
+                archive_failed_xml(recovered_document, recovered_tree, settings, logger)
                 summary.recovered += 1
                 logger.warning(
                     "layer=xml job=%s status=failed action=recovered",
@@ -600,6 +691,8 @@ def run_polling_layer(
             if settings.mode == "recover":
                 contents = missing_status_xml(candidate, settings.output_url or "", now)
                 if create_missing_status_file(status_path, contents):
+                    recovered_document, recovered_tree = read_xml_status(status_path)
+                    archive_failed_xml(recovered_document, recovered_tree, settings, logger)
                     summary.recovered += 1
                     logger.warning(
                         "layer=polling job=%s status=failed action=recovered polls=%d",
@@ -942,8 +1035,14 @@ def parse_args(argv: list[str] | None = None) -> Settings:
     if args.mode == "statistics":
         args.status_counts = True
     limit = args.limit
-    if limit is None and args.mode == "recover":
-        limit = int(control_config.get("recovery_limit", "100"))
+    recovery_limit = int(control_config.get("recovery_limit", "100"))
+    missing_status_recovery_limit = int(
+        control_config.get("missing_status_recovery_limit", "20")
+    )
+    incident_archive_enabled = control_config.getboolean(
+        "incident_archive_enabled", fallback=False
+    )
+    incident_archive_dir = optional_path(control_config.get("incident_archive_dir"))
     layers = args.layer or configured_layers
     invalid = sorted(set(layers) - set(SUPPORTED_LAYERS))
     if invalid:
@@ -954,6 +1053,10 @@ def parse_args(argv: list[str] | None = None) -> Settings:
         parser.error("--stale-after-minutes must be greater than zero")
     if limit is not None and limit <= 0:
         parser.error("--limit must be greater than zero")
+    if recovery_limit <= 0 or missing_status_recovery_limit <= 0:
+        parser.error("configured recovery limits must be greater than zero")
+    if incident_archive_enabled and incident_archive_dir is None:
+        parser.error("incident_archive_dir is required when incident archiving is enabled")
     if args.status_counts and args.mode not in {"monitor", "statistics"}:
         parser.error("--status-counts is only available in monitor or statistics mode")
     if args.poll_window_minutes <= 0:
@@ -995,6 +1098,10 @@ def parse_args(argv: list[str] | None = None) -> Settings:
         ),
         statistics_enabled=control_config.getboolean("statistics_enabled", fallback=True),
         service_name=(preliminary.config.stem if preliminary.config else "unknown"),
+        incident_archive_enabled=incident_archive_enabled,
+        incident_archive_dir=incident_archive_dir,
+        recovery_limit=recovery_limit,
+        missing_status_recovery_limit=missing_status_recovery_limit,
     )
 
 
@@ -1055,7 +1162,11 @@ def execute_layers(
         "polling": run_polling_layer,
     }
     summaries: list[LayerSummary] = []
-    for layer in settings.layers:
+    layers = settings.layers
+    if settings.mode == "recover":
+        order = {"xml": 0, "database": 1, "polling": 2}
+        layers = sorted(layers, key=order.__getitem__)
+    for layer in layers:
         if not layer_is_enabled(settings, layer):
             logger.info(
                 "layer=%s result=skip reason=recovery-disabled",
@@ -1063,7 +1174,14 @@ def execute_layers(
             )
             continue
         try:
-            summary = runners[layer](settings, now, logger)
+            layer_limit = settings.limit
+            if settings.mode == "recover" and layer_limit is None:
+                layer_limit = (
+                    settings.missing_status_recovery_limit
+                    if layer == "polling"
+                    else settings.recovery_limit
+                )
+            summary = runners[layer](replace(settings, limit=layer_limit), now, logger)
         except Exception as error:
             logger.exception("layer=%s decision=error reason=%s", layer, error)
             summary = LayerSummary(layer, errors=1)

--- a/tests/configuration.yml
+++ b/tests/configuration.yml
@@ -49,6 +49,10 @@
           - pywps_job_control_schedule.hour == '*'
           - pywps_job_control_stale_after_minutes | float > 0
           - pywps_job_control_recovery_limit | int == 100
+          - pywps_job_incident_archive_enabled
+          - pywps_job_incident_archive_dir == '/var/lib/pywps/job-incidents'
+          - pywps_job_incident_keep_days == 30
+          - pywps_job_incident_keep_minutes | int == 43200
           - >-
             pywps_job_control_stale_after_minutes | float
             < wps_outputs_keep_minutes | float
@@ -56,7 +60,6 @@
           - not pywps_job_control_recovery_enabled
           - pywps_job_control_layers == ['xml', 'database']
           - not pywps_missing_status_recovery_enabled
-          - pywps_missing_status_recovery_schedule.minute == '2-57/5'
           - pywps_missing_status_poll_window_minutes == 60
           - pywps_missing_status_min_poll_count == 3
           - pywps_missing_status_min_poll_duration_minutes == 15
@@ -335,6 +338,11 @@
           - "'layers = xml,database' in test_pywps_config"
           - "'stale_after_minutes = 120' in test_pywps_config"
           - "'recovery_limit = 100' in test_pywps_config"
+          - "'incident_archive_enabled = true' in test_pywps_config"
+          - >-
+            'incident_archive_dir = /var/lib/pywps/job-incidents/alpha'
+            in test_pywps_config
+          - "'missing_status_recovery_limit = 20' in test_pywps_config"
           - "'LoadPlugin load' in test_collectd_load_config"
           - "'LoadPlugin df' not in test_collectd_load_config"
           - "'LoadPlugin memory' not in test_collectd_load_config"

--- a/tests/test_job_control.py
+++ b/tests/test_job_control.py
@@ -225,6 +225,43 @@ class RecoverStalledJobsTests(unittest.TestCase):
                 self.assertEqual(summary.stalled, 0)
                 self.assertEqual(self.status.read_bytes(), before)
 
+    def test_failed_status_is_archived_once_with_searchable_filename(self):
+        self.write_status("ProcessFailed")
+        settings = self.settings()
+        settings.service_name = "alpha"
+        settings.incident_archive_enabled = True
+        settings.incident_archive_dir = self.root / "incidents"
+        original = self.status.read_bytes()
+
+        MODULE.run_xml_layer(settings, self.now, mock.Mock())
+        MODULE.run_xml_layer(settings, self.now, mock.Mock())
+
+        archived = list(settings.incident_archive_dir.glob("*.xml"))
+        self.assertEqual(len(archived), 1)
+        self.assertEqual(
+            archived[0].name,
+            f"20260731T020000Z__error__alpha__test-process__{JOB_UUID}.xml",
+        )
+        self.assertEqual(archived[0].read_bytes(), original)
+        self.assertEqual(archived[0].stat().st_mode & 0o777, 0o640)
+
+    def test_recovered_status_is_archived_after_failure_rewrite(self):
+        self.write_status("ProcessStarted")
+        settings = self.settings("recover")
+        settings.service_name = "alpha"
+        settings.incident_archive_enabled = True
+        settings.incident_archive_dir = self.root / "incidents"
+
+        MODULE.run_xml_layer(settings, self.now, mock.Mock())
+
+        archived = list(settings.incident_archive_dir.glob("*.xml"))
+        self.assertEqual(len(archived), 1)
+        self.assertEqual(
+            archived[0].name,
+            f"20260731T100000Z__recovered__alpha__test-process__{JOB_UUID}.xml",
+        )
+        self.assertIn(b"stalled-job recovery", archived[0].read_bytes())
+
     def test_unknown_process_state_is_nonfinal(self):
         self.write_status("ProcessQueued")
         summary = MODULE.run_xml_layer(self.settings(), self.now, mock.Mock())
@@ -248,6 +285,9 @@ class RecoverStalledJobsTests(unittest.TestCase):
 
     def test_access_log_recovery_creates_failure_after_repeated_recent_404s(self):
         settings = self.polling_settings()
+        settings.service_name = "alpha"
+        settings.incident_archive_enabled = True
+        settings.incident_archive_dir = self.root / "incidents"
         settings.access_log.write_text(
             "".join(
                 self.access_log_line(self.now - timedelta(minutes=minutes))
@@ -267,6 +307,12 @@ class RecoverStalledJobsTests(unittest.TestCase):
         self.assertEqual(document.state, "ProcessFailed")
         self.assertEqual(document.creation_time, self.now)
         self.assertEqual(self.status.stat().st_mode & 0o777, 0o644)
+        archived = list(settings.incident_archive_dir.glob("*.xml"))
+        self.assertEqual(len(archived), 1)
+        self.assertEqual(
+            archived[0].name,
+            f"20260731T100000Z__recovered__alpha__unknown__{JOB_UUID}.xml",
+        )
         logger.warning.assert_called_once_with(
             "layer=polling job=%s status=failed action=recovered polls=%d",
             JOB_UUID,
@@ -452,10 +498,13 @@ class RecoverStalledJobsTests(unittest.TestCase):
             "layers = xml, database\n"
             "stale_after_minutes = 360\n"
             "recovery_limit = 100\n"
+            "incident_archive_enabled = true\n"
+            f"incident_archive_dir = {self.root / 'incidents'}\n"
             f"access_log = {self.root / 'nginx-access.log'}\n"
             "poll_window_minutes = 45\n"
             "min_poll_count = 4\n"
             "min_poll_duration_minutes = 7\n"
+            "missing_status_recovery_limit = 20\n"
             "missing_status_database_guard = true\n"
             f"lock_file = {self.root / 'configured.lock'}\n",
             encoding="utf-8",
@@ -476,6 +525,10 @@ class RecoverStalledJobsTests(unittest.TestCase):
         self.assertTrue(settings.recovery_enabled)
         self.assertTrue(settings.missing_status_recovery_enabled)
         self.assertTrue(settings.statistics_enabled)
+        self.assertTrue(settings.incident_archive_enabled)
+        self.assertEqual(settings.incident_archive_dir, self.root / "incidents")
+        self.assertEqual(settings.recovery_limit, 100)
+        self.assertEqual(settings.missing_status_recovery_limit, 20)
         self.assertEqual(settings.service_name, "alpha")
         self.assertEqual(
             settings.log_file,
@@ -493,7 +546,7 @@ class RecoverStalledJobsTests(unittest.TestCase):
         ])
         self.assertEqual(overridden.layers, ["xml"])
         self.assertEqual(overridden.stale_after_minutes, 720)
-        self.assertEqual(overridden.limit, 100)
+        self.assertIsNone(overridden.limit)
 
         selected_layers = MODULE.parse_args([
             "--config",
@@ -618,6 +671,27 @@ class RecoverStalledJobsTests(unittest.TestCase):
         logger.info.assert_any_call(
             "layer=%s result=skip reason=recovery-disabled", "polling"
         )
+
+    def test_recovery_uses_fixed_layer_order_and_independent_limits(self):
+        settings = self.settings("recover", ["polling", "database", "xml"])
+        settings.missing_status_recovery_enabled = True
+        calls = []
+
+        def record(layer):
+            def runner(received, *_args):
+                calls.append((layer, received.limit))
+                return MODULE.LayerSummary(layer)
+
+            return runner
+
+        MODULE.execute_layers(
+            settings,
+            self.now,
+            mock.Mock(),
+            runners={layer: record(layer) for layer in settings.layers},
+        )
+
+        self.assertEqual(calls, [("xml", 100), ("database", 100), ("polling", 20)])
 
     def test_summary_severity_reflects_layer_result(self):
         cases = (


### PR DESCRIPTION
This PR adds an archive folder in the pywps outputs were xml status documents of failed jobs are kept. The job control script checks for failed jobs and copies the status documents there including a timestamp.