### PR TITLE
Cleanup recovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@ Changes:
 - enable the read-only Slurm monitor by default and simplify PyWPS job control
   to the `monitor`, ordered `recover`, and `statistics` operator commands
 - standardize public PyWPS role variables on the established `wps_` prefix
+- reduce hourly job statistics to one current-status line including unique and
+  per-layer stalled-job counts
 
 ## 0.9.0 (2026-07-31)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Changes:
   searchable, per-service 30-day incident archive with UTC filenames
 - enable the read-only Slurm monitor by default and simplify PyWPS job control
   to the `monitor`, ordered `recover`, and `statistics` operator commands
+- standardize public PyWPS role variables on the established `wps_` prefix
 
 ## 0.9.0 (2026-07-31)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ Changes:
 - standardize public PyWPS role variables on the established `wps_` prefix
 - reduce hourly job statistics to one current-status line including unique and
   per-layer stalled-job counts
+- warn about long-running non-final WPS requests before they become stale,
+  using the database request start time and a configurable 10-minute default
 
 ## 0.9.0 (2026-07-31)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ Changes:
   recovery on a five-minute cadence, and retain hourly job statistics
 - preserve failed and recovery-generated PyWPS status documents in a
   searchable, per-service 30-day incident archive with UTC filenames
+- enable the read-only Slurm monitor by default and simplify PyWPS job control
+  to the `monitor`, ordered `recover`, and `statistics` operator commands
 
 ## 0.9.0 (2026-07-31)
 

--- a/README.md
+++ b/README.md
@@ -320,11 +320,11 @@ PyWPS services restart daily by default when cron is enabled. Scheduled
 restarts can be disabled, or the schedule changed to hourly:
 
 ```yaml
-pywps_restart_enabled: true
-pywps_restart_schedule: daily  # hourly or daily
+wps_restart_enabled: true
+wps_restart_schedule: daily  # hourly or daily
 ```
 
-Set `pywps_restart_enabled: false` to disable the cron entry. The script
+Set `wps_restart_enabled: false` to disable the cron entry. The script
 remains available and can still be run manually:
 
 ```sh
@@ -339,18 +339,18 @@ explicit switches are enabled:
 
 ```yaml
 cron_enabled: true
-pywps_job_control_monitor_enabled: true
-pywps_job_control_recovery_enabled: false
-pywps_job_control_schedule:
+wps_job_control_monitor_enabled: true
+wps_job_control_recovery_enabled: false
+wps_job_control_schedule:
   minute: "*/5"
   hour: "*"
-pywps_job_control_recovery_schedule:
+wps_job_control_recovery_schedule:
   minute: "1-56/5"
   hour: "*"
-pywps_job_control_stale_after_minutes: 120
-pywps_job_control_recovery_limit: 100
-pywps_job_incident_archive_enabled: true
-pywps_job_incident_keep_days: 30
+wps_job_control_stale_after_minutes: 120
+wps_job_control_recovery_limit: 100
+wps_job_incident_archive_enabled: true
+wps_job_incident_keep_days: 30
 ```
 
 The monitor runs every five minutes. It does not change live request state,
@@ -395,8 +395,8 @@ This path is derived from the service's existing `[logging] file` setting.
 The existing `/etc/logrotate.d/pywps` wildcard manages this log together with
 the other PyWPS logs. By default, a log becomes eligible for rotation after
 one day only when it exceeds `10M`; both the size and retained archive count
-are configurable with `pywps_logrotate_min_size` and
-`pywps_logrotate_rotations`.
+are configurable with `wps_logrotate_min_size` and
+`wps_logrotate_rotations`.
 
 Individual stalled findings are written to the log file. Scheduled runs emit
 a single warning summary for each layer containing stalled jobs, rather than
@@ -444,11 +444,11 @@ database. `--stale-after-minutes` overrides the configured threshold.
 `--limit` caps the number of stalled jobs processed in each selected layer.
 The database applies a limit oldest-first in SQL, which keeps initial recovery
 batches bounded even when years of unfinished requests have accumulated.
-Recovery defaults to `pywps_job_control_recovery_limit`, which is 100. Monitoring
+Recovery defaults to `wps_job_control_recovery_limit`, which is 100. Monitoring
 remains unlimited unless `--limit` is explicitly supplied, so an old backlog
 cannot hide newer stalled requests. An explicit `--limit` overrides the
 configured recovery defaults for every selected layer. Polling recovery uses
-its separate default of `pywps_missing_status_recovery_limit`, which is 20.
+its separate default of `wps_missing_status_recovery_limit`, which is 20.
 The underlying `--status-counts` option enables a complete database aggregate
 for explicit low-level invocations.
 
@@ -458,9 +458,9 @@ Failed PyWPS status documents are copied into a separate, bounded archive
 before routine output cleanup can remove them:
 
 ```yaml
-pywps_job_incident_archive_enabled: true
-pywps_job_incident_archive_dir: /var/lib/pywps/job-incidents
-pywps_job_incident_keep_days: 30
+wps_job_incident_archive_enabled: true
+wps_job_incident_archive_dir: /var/lib/pywps/job-incidents
+wps_job_incident_keep_days: 30
 ```
 
 Each service has its own subdirectory. Files use UTC timestamps and searchable
@@ -489,8 +489,8 @@ When cron is enabled, a separate read-only statistics job runs hourly at four
 minutes past the hour by default:
 
 ```yaml
-pywps_job_statistics_enabled: true
-pywps_job_statistics_schedule:
+wps_job_statistics_enabled: true
+wps_job_statistics_schedule:
   minute: "4"
   hour: "*"
 ```
@@ -518,14 +518,14 @@ a WPS 1.0 `ProcessFailed` status document so clients such as OWSLib can finish
 instead of polling forever.
 
 ```yaml
-pywps_job_control_recovery_enabled: true
-pywps_missing_status_recovery_enabled: true
-pywps_missing_status_poll_window_minutes: 60
-pywps_missing_status_min_poll_count: 3
-pywps_missing_status_min_poll_duration_minutes: 15
-pywps_missing_status_recovery_limit: 20
-pywps_missing_status_access_log: /var/log/nginx/access.log
-pywps_missing_status_database_guard: true
+wps_job_control_recovery_enabled: true
+wps_missing_status_recovery_enabled: true
+wps_missing_status_poll_window_minutes: 60
+wps_missing_status_min_poll_count: 3
+wps_missing_status_min_poll_duration_minutes: 15
+wps_missing_status_recovery_limit: 20
+wps_missing_status_access_log: /var/log/nginx/access.log
+wps_missing_status_database_guard: true
 ```
 
 The default recovery schedule runs every five minutes at minute 1 and considers
@@ -625,7 +625,7 @@ recovery reconciles a request which remains non-final. Both limits can be
 overridden independently, but the Slurm timeout must remain shorter:
 
 ```yaml
-pywps_job_control_stale_after_minutes: 120
+wps_job_control_stale_after_minutes: 120
 slurm_job_timeout_minutes: 90
 ```
 

--- a/README.md
+++ b/README.md
@@ -495,15 +495,18 @@ wps_job_statistics_schedule:
   hour: "*"
 ```
 
-It records complete XML and database layer summaries plus a full status
+It records one `current_status` line per run in
+`/var/log/pywps/SERVICE_NAME-stats.log`. The line contains the complete database
 aggregate using the OGC API Processes vocabulary: accepted, running,
-successful, failed, and dismissed. PyWPS `started` and `paused` records are
-combined as `running`; missing or unrecognized values are reported as
-`unmapped`. These counts cover the complete request table. Routine individual
-findings are excluded from `/var/log/pywps/SERVICE_NAME-stats.log`,
-and only errors are written to the cron console. The statistics log uses the
-same daily maximum frequency and configured minimum-size threshold as the
-other service logs. Run the same report manually with:
+successful, failed, dismissed, and unmapped. PyWPS `started` and `paused`
+records are combined as `running`. It also reports the unique stalled-job
+count, the separate XML and database stalled counts, the number of XML status
+documents, and layer errors. A request stalled in both XML and the database is
+counted only once in `stalled`. Routine individual findings are excluded, and
+only actual errors add extra log records or reach the cron console. The
+statistics log uses the same daily maximum frequency and configured
+minimum-size threshold as the other service logs. Run the same report manually
+with:
 
 ```sh
 sudo /var/lib/pywps/statistics SERVICE_NAME

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ wps_job_control_schedule:
 wps_job_control_recovery_schedule:
   minute: "1-56/5"
   hour: "*"
+wps_job_control_long_running_minutes: 10
 wps_job_control_stale_after_minutes: 120
 wps_job_control_recovery_limit: 100
 wps_job_incident_archive_enabled: true
@@ -358,6 +359,10 @@ but it preserves failed XML documents in the incident archive. When recovery
 is enabled, one locked recovery command runs every five minutes with a
 one-minute offset. It always processes XML, database, and then polling evidence;
 disabled polling recovery is skipped within that ordered run.
+The database layer reports non-final requests as long-running after 10 minutes
+by default, based on their request start time. This is an early warning only;
+the request is not recovered until it also reaches the separate 120-minute
+stale threshold without a status update.
 Standard cron fields
 `minute`, `hour`, `day`, `month`, and `weekday` are configurable. When the XML
 layer and scheduled output cleanup are enabled, the stale threshold must be
@@ -502,8 +507,10 @@ successful, failed, dismissed, and unmapped. PyWPS `started` and `paused`
 records are combined as `running`. It also reports the unique stalled-job
 count, the separate XML and database stalled counts, the number of XML status
 documents, and layer errors. A request stalled in both XML and the database is
-counted only once in `stalled`. Routine individual findings are excluded, and
-only actual errors add extra log records or reach the cron console. The
+counted only once in `stalled`. The line also includes the number of non-final
+database requests beyond the long-running warning threshold. Routine
+individual findings are excluded, and only actual errors add extra log records
+or reach the cron console. The
 statistics log uses the same daily maximum frequency and configured
 minimum-size threshold as the other service logs. Run the same report manually
 with:

--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ remains available and can still be run manually:
 
 ### Monitor and recover stalled jobs
 
-The playbook installs the job-control script once. Scheduled monitoring is
-read-only. Scheduled recovery remains disabled until its explicit switches are
-enabled:
+The playbook installs the job-control script once. Scheduled monitoring does
+not change live request state. Scheduled recovery remains disabled until its
+explicit switches are enabled:
 
 ```yaml
 cron_enabled: true
@@ -351,9 +351,6 @@ pywps_job_control_stale_after_minutes: 120
 pywps_job_control_recovery_limit: 100
 pywps_job_incident_archive_enabled: true
 pywps_job_incident_keep_days: 30
-pywps_job_control_layers:
-  - xml
-  - database
 ```
 
 The monitor runs every five minutes. It does not change live request state,
@@ -415,42 +412,35 @@ terminal. It does not calculate the complete database status aggregate. The
 five-minute scheduled monitor performs the same all-layer check and remains quiet
 unless it finds stalled jobs or errors.
 
-Recover only stalled XML documents with:
+Recover stalled jobs with the single ordered operator command:
 
 ```sh
-sudo /var/lib/pywps/recover-xml SERVICE_NAME
+sudo /var/lib/pywps/recover SERVICE_NAME
 ```
 
-Recover the XML and database layers together with:
-
-```sh
-sudo /var/lib/pywps/recover-xml-db SERVICE_NAME
-```
-
-Recovery atomically changes stalled XML documents to `ProcessFailed`. In the
-database it marks the existing request failed and removes a matching stored
-queue entry; it does not change the database schema. The generated
+Recovery always runs XML, database, and polling in that order under one
+per-service lock. It atomically changes stalled XML documents to
+`ProcessFailed`. In the database it marks the existing request failed and
+removes a matching stored queue entry; it does not change the database schema.
+Polling recovery is skipped unless its separate switch is enabled. The generated
 `[job_control]` section lives in the service's existing PyWPS configuration,
 and each cron entry uses that service's Conda environment and configuration.
 Command-line options override those defaults, for example:
 
 ```sh
 sudo /var/lib/pywps/monitor SERVICE_NAME --stale-after-minutes 720
-sudo /var/lib/pywps/recover-xml SERVICE_NAME --stale-after-minutes 720
-sudo /var/lib/pywps/recover-xml-db SERVICE_NAME --limit 500
+sudo /var/lib/pywps/recover SERVICE_NAME --stale-after-minutes 720
+sudo /var/lib/pywps/recover SERVICE_NAME --limit 500
 ```
 
-The concise command names are intentionally scoped by their installation in
-`/var/lib/pywps`: `monitor` checks all layers, `recover-xml` changes only XML,
-`recover-polling` handles missing status documents found through polling, and
-`recover-xml-db` selects XML and database. The deployed implementation is
-`pywps-job-control.py`.
+The concise commands installed in `/var/lib/pywps` are `monitor`, `recover`,
+and `statistics`. The deployed implementation is `pywps-job-control.py`.
 
 The installed helpers have fixed layer scopes and reject `--layer`. For custom
-selection, call `pywps-job-control.py` directly and repeat `--layer`, for
-example `--layer xml --layer database`. Without an explicit layer, the script
-uses the service's `[job_control] layers` setting. `--stale-after-minutes`
-overrides the configured threshold.
+diagnosis, call `pywps-job-control.py` directly and repeat `--layer`, for
+example `--layer xml --layer database`. Without explicit layers, monitoring
+and recovery use all three layers in their safe order; statistics uses XML and
+database. `--stale-after-minutes` overrides the configured threshold.
 `--limit` caps the number of stalled jobs processed in each selected layer.
 The database applies a limit oldest-first in SQL, which keeps initial recovery
 batches bounded even when years of unfinished requests have accumulated.
@@ -569,9 +559,9 @@ output directory, is mode `0644`, contains a UTC creation time and useful
 failure message, and is recorded as a warning in the existing per-service
 stalled-job log. Each run recovers at most 20 documents by default.
 
-The `monitor` shortcut checks XML, database, and polling without changing
-state. Recover polling candidates only when intended with
-`sudo /var/lib/pywps/recover-polling SERVICE_NAME`.
+The `monitor` shortcut checks XML, database, and polling without changing live
+request state. The unified `recover` command handles qualifying polling
+candidates only when both recovery switches are enabled.
 
 ### Use Conda to build identical environments
 
@@ -644,13 +634,14 @@ limit even when PyWPS does not pass `--time` during submission and cannot
 request a higher limit. This native enforcement does not require Slurm
 accounting or `slurmdbd`.
 
-An independent, optional read-only monitor makes one `squeue` request for
-`PENDING` and `RUNNING` jobs owned by the configured PyWPS Unix account. Because
-every PyWPS service uses the same account on the dedicated VM, Ansible creates
-one cron entry rather than one per service.
+An independent read-only monitor makes one `squeue` request for `PENDING` and
+`RUNNING` jobs owned by the configured PyWPS Unix account. It is enabled by
+default whenever Slurm and cron are enabled, and can still be disabled
+explicitly. Because every PyWPS service uses the same account on the dedicated
+VM, Ansible creates one cron entry rather than one per service.
 
 ```yaml
-slurm_job_monitor_enabled: true
+slurm_job_monitor_enabled: true  # enabled by default when Slurm is enabled
 slurm_job_monitor_schedule:
   minute: "*/5"
   hour: "*"

--- a/TODO.md
+++ b/TODO.md
@@ -46,9 +46,6 @@ by the PyWPS deployment.
   specifications during the longer PyWPS environment update. In particular,
   retain the Conda-linked `psycopg2` build: the pip `psycopg2-binary` wheel's
   bundled libraries segfaulted on a fresh Python 3.13 connection.
-- Consolidate and clean up the monitoring and recovery scripts after further
-  production validation. Normalize locking, scheduling, batch limits, logging,
-  and exit status handling, and remove obsolete compatibility paths.
 - Consider temporary-work-directory cleanup only after it can be associated
   with a request without risking another active job's files.
 

--- a/etc/sample-production.yml
+++ b/etc/sample-production.yml
@@ -39,10 +39,6 @@ pywps_job_control_recovery_limit: 100
 pywps_job_incident_archive_enabled: true
 pywps_job_incident_archive_dir: /var/lib/pywps/job-incidents
 pywps_job_incident_keep_days: 30
-# Layers used when a command does not specify --layer.
-pywps_job_control_layers:
-  - xml
-  - database
 # Create failure XML for repeated Nginx 404 status polling.
 pywps_missing_status_recovery_enabled: false
 pywps_missing_status_poll_window_minutes: 60
@@ -73,8 +69,8 @@ ssl_certs_privkey_path: /etc/ssl/wps.example.org/wps.example.org.key
 slurm_enabled: false
 # Stop the Slurm process before PyWPS treats its request as stale.
 slurm_job_timeout_minutes: 90
-# Optionally report queue pressure and jobs approaching the hard timeout.
-slurm_job_monitor_enabled: false
+# Report queue pressure and jobs approaching the hard timeout when Slurm is enabled.
+slurm_job_monitor_enabled: true
 slurm_job_monitor_long_running_minutes: 10
 slurm_job_monitor_pending_warning: 20
 slurm_job_monitor_alert_file: /run/pywps/slurm-red-alert.json

--- a/etc/sample-production.yml
+++ b/etc/sample-production.yml
@@ -11,41 +11,41 @@ cron_mailto: ops@example.org
 cron_user: root
 wps_outputs_keep_hours: 24
 wps_temp_keep_hours: 12
-pywps_restart_enabled: true
-pywps_restart_schedule: daily
+wps_restart_enabled: true
+wps_restart_schedule: daily
 # Rotate PyWPS logs after one day only when they exceed this size.
-pywps_logrotate_min_size: 10M
-pywps_logrotate_rotations: 7
+wps_logrotate_min_size: 10M
+wps_logrotate_rotations: 7
 # First deploy stalled-job checks in report-only mode and review their log.
 # Report stalled requests without changing them.
-pywps_job_control_monitor_enabled: true
+wps_job_control_monitor_enabled: true
 # Allow commands that recover stalled requests or status documents.
-pywps_job_control_recovery_enabled: false
+wps_job_control_recovery_enabled: false
 # Write a complete hourly job statistics report.
-pywps_job_statistics_enabled: true
-pywps_job_statistics_schedule:
+wps_job_statistics_enabled: true
+wps_job_statistics_schedule:
   minute: "4"
   hour: "*"
-pywps_job_control_schedule:
+wps_job_control_schedule:
   minute: "*/5"
   hour: "*"
-pywps_job_control_recovery_schedule:
+wps_job_control_recovery_schedule:
   minute: "1-56/5"
   hour: "*"
-pywps_job_control_stale_after_minutes: 120
+wps_job_control_stale_after_minutes: 120
 # Maximum recovered jobs per layer.
-pywps_job_control_recovery_limit: 100
+wps_job_control_recovery_limit: 100
 # Preserve failed status XML for later investigation.
-pywps_job_incident_archive_enabled: true
-pywps_job_incident_archive_dir: /var/lib/pywps/job-incidents
-pywps_job_incident_keep_days: 30
+wps_job_incident_archive_enabled: true
+wps_job_incident_archive_dir: /var/lib/pywps/job-incidents
+wps_job_incident_keep_days: 30
 # Create failure XML for repeated Nginx 404 status polling.
-pywps_missing_status_recovery_enabled: false
-pywps_missing_status_poll_window_minutes: 60
-pywps_missing_status_min_poll_count: 3
-pywps_missing_status_min_poll_duration_minutes: 15
-pywps_missing_status_recovery_limit: 20
-pywps_missing_status_database_guard: true
+wps_missing_status_recovery_enabled: false
+wps_missing_status_poll_window_minutes: 60
+wps_missing_status_min_poll_count: 3
+wps_missing_status_min_poll_duration_minutes: 15
+wps_missing_status_recovery_limit: 20
+wps_missing_status_database_guard: true
 
 # Use a separately managed PostgreSQL database.
 db_install_postgresql: false

--- a/etc/sample-production.yml
+++ b/etc/sample-production.yml
@@ -32,6 +32,7 @@ wps_job_control_schedule:
 wps_job_control_recovery_schedule:
   minute: "1-56/5"
   hour: "*"
+wps_job_control_long_running_minutes: 10
 wps_job_control_stale_after_minutes: 120
 # Maximum recovered jobs per layer.
 wps_job_control_recovery_limit: 100

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -177,51 +177,51 @@ cron_enabled: false
 cron_disabled: "{{ cron_enabled | bool == false }}"
 cron_mailto: root
 cron_user: root
-pywps_restart_enabled: true
-pywps_restart_schedule: daily
+wps_restart_enabled: true
+wps_restart_schedule: daily
 # Rotate PyWPS logs after one day only when they exceed this size.
-pywps_logrotate_min_size: 10M
-pywps_logrotate_rotations: 7
+wps_logrotate_min_size: 10M
+wps_logrotate_rotations: 7
 # Report stalled requests without changing them.
-pywps_job_control_monitor_enabled: true
+wps_job_control_monitor_enabled: true
 # Allow commands that recover stalled requests or status documents.
-pywps_job_control_recovery_enabled: false
+wps_job_control_recovery_enabled: false
 # Write a complete hourly job statistics report.
-pywps_job_statistics_enabled: true
-pywps_job_statistics_schedule:
+wps_job_statistics_enabled: true
+wps_job_statistics_schedule:
   minute: "4"
   hour: "*"
   day: "*"
   month: "*"
   weekday: "*"
-pywps_job_control_schedule:
+wps_job_control_schedule:
   minute: "*/5"
   hour: "*"
   day: "*"
   month: "*"
   weekday: "*"
-pywps_job_control_recovery_schedule:
+wps_job_control_recovery_schedule:
   minute: "1-56/5"
   hour: "*"
   day: "*"
   month: "*"
   weekday: "*"
-pywps_job_control_stale_after_minutes: 120
+wps_job_control_stale_after_minutes: 120
 # Maximum recovered jobs per layer.
-pywps_job_control_recovery_limit: 100
+wps_job_control_recovery_limit: 100
 # Preserve failed status documents separately from routine output cleanup.
-pywps_job_incident_archive_enabled: true
-pywps_job_incident_archive_dir: "{{ service_user_home }}/job-incidents"
-pywps_job_incident_keep_days: 30
-pywps_job_incident_keep_minutes: "{{ (pywps_job_incident_keep_days | int) * 1440 }}"
+wps_job_incident_archive_enabled: true
+wps_job_incident_archive_dir: "{{ service_user_home }}/job-incidents"
+wps_job_incident_keep_days: 30
+wps_job_incident_keep_minutes: "{{ (wps_job_incident_keep_days | int) * 1440 }}"
 # Create failure XML for repeated Nginx 404 status polling.
-pywps_missing_status_recovery_enabled: false
-pywps_missing_status_poll_window_minutes: 60
-pywps_missing_status_min_poll_count: 3
-pywps_missing_status_min_poll_duration_minutes: 15
-pywps_missing_status_recovery_limit: 20
-pywps_missing_status_access_log: "{{ wps_http_log_dir }}/access.log"
-pywps_missing_status_database_guard: true
+wps_missing_status_recovery_enabled: false
+wps_missing_status_poll_window_minutes: 60
+wps_missing_status_min_poll_count: 3
+wps_missing_status_min_poll_duration_minutes: 15
+wps_missing_status_recovery_limit: 20
+wps_missing_status_access_log: "{{ wps_http_log_dir }}/access.log"
+wps_missing_status_database_guard: true
 
 # selinux
 # https://docs.ansible.com/ansible/latest/collections/community/general/sefcontext_module.html
@@ -241,7 +241,7 @@ wps_enable_acl: false
 wps_acl_allow: []
 wps_run_dir: /run/pywps
 wps_database: "postgresql+psycopg2://{{ db_user }}:{{ db_password }}@{{ db_host }}:{{ db_port }}/pywps"
-pywps_webservice_enabled: true
+wps_webservice_enabled: true
 wps_basedir: "{{ service_user_home }}"
 wps_cache_dir: "{{ wps_basedir }}/cache"
 # Cache WPS GetCapabilities and DescribeProcess responses.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -75,8 +75,8 @@ slurm_munge_key: /etc/munge/munge.key
 slurm_configure_munge: false
 # Slurm stops the process before PyWPS treats its request as stale.
 slurm_job_timeout_minutes: 90
-# Optionally report host-wide Slurm queue pressure and long-running jobs.
-slurm_job_monitor_enabled: false
+# Report host-wide Slurm queue pressure and long-running jobs by default.
+slurm_job_monitor_enabled: true
 slurm_job_monitor_schedule:
   minute: "*/5"
   hour: "*"
@@ -214,10 +214,6 @@ pywps_job_incident_archive_enabled: true
 pywps_job_incident_archive_dir: "{{ service_user_home }}/job-incidents"
 pywps_job_incident_keep_days: 30
 pywps_job_incident_keep_minutes: "{{ (pywps_job_incident_keep_days | int) * 1440 }}"
-# Layers used when a command does not specify --layer.
-pywps_job_control_layers:
-  - xml
-  - database
 # Create failure XML for repeated Nginx 404 status polling.
 pywps_missing_status_recovery_enabled: false
 pywps_missing_status_poll_window_minutes: 60

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -206,6 +206,8 @@ wps_job_control_recovery_schedule:
   day: "*"
   month: "*"
   weekday: "*"
+# Warn about non-final database requests running this long.
+wps_job_control_long_running_minutes: 10
 wps_job_control_stale_after_minutes: 120
 # Maximum recovered jobs per layer.
 wps_job_control_recovery_limit: 100

--- a/playbook.yml
+++ b/playbook.yml
@@ -29,7 +29,7 @@
     - role: galaxyproject.slurm
       when: slurm_enabled
     - role: pywps
-      pywps_webservice_enabled: true
+      wps_webservice_enabled: true  # noqa var-naming[no-role-prefix]
     - role: roocs
       when: roocs_enabled
 
@@ -56,6 +56,6 @@
     - role: andrewrothstein.miniconda
       tags: conda
     - role: pywps
-      pywps_webservice_enabled: false
+      wps_webservice_enabled: false  # noqa var-naming[no-role-prefix]
     - role: roocs
       when: roocs_enabled

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -70,8 +70,6 @@
       - pywps_job_incident_keep_days | int > 0
       - pywps_job_incident_keep_minutes | int > 0
       - pywps_job_incident_archive_dir | length > 0
-      - pywps_job_control_layers | length > 0
-      - pywps_job_control_layers | difference(['xml', 'database', 'polling']) | length == 0
       - pywps_missing_status_poll_window_minutes | float > 0
       - pywps_missing_status_min_poll_count | int > 0
       - pywps_missing_status_min_poll_duration_minutes | float >= 0
@@ -82,15 +80,14 @@
       - >-
         not (cron_enabled | bool)
         or not (pywps_job_control_monitor_enabled | bool)
-        or 'xml' not in pywps_job_control_layers
         or (pywps_job_control_stale_after_minutes | float) < (wps_outputs_keep_minutes | float)
     fail_msg: >-
       The job-control schedule must be a cron-field mapping, age must be
       positive and shorter than output retention for scheduled XML checks,
-      recovery limit must be positive, and layers must contain xml, database,
-      or polling. Incident retention must be positive. Missing-status recovery
-      also requires a positive polling window, poll count and recovery limit,
-      and a minimum poll duration shorter than its polling window.
+      and recovery and incident-retention limits must be positive.
+      Missing-status recovery also requires a positive polling window, poll
+      count and recovery limit, and a minimum poll duration shorter than its
+      polling window.
 
 - name: Install PyWPS job-control script
   ansible.builtin.copy:
@@ -205,11 +202,6 @@
       {{ (cron_disabled | bool) or not (slurm_job_monitor_enabled | bool) }}
     state: "{{ 'present' if slurm_enabled | bool else 'absent' }}"
 
-- name: Remove obsolete stalled-job script alias
-  ansible.builtin.file:
-    path: "{{ cron_script_dir }}/recover-stalled-jobs.py"
-    state: absent
-
 - name: Install PyWPS job operator commands
   ansible.builtin.template:
     src: ./templates/job-control-helper.sh.j2
@@ -219,9 +211,7 @@
     mode: "0755"
   loop:
     - monitor
-    - recover-xml
-    - recover-polling
-    - recover-xml-db
+    - recover
     - statistics
 
 - name: Remove obsolete recovery commands
@@ -229,8 +219,11 @@
     path: "{{ cron_script_dir }}/{{ item }}"
     state: absent
   loop:
-    - recover
     - recover-all
+    - recover-polling
+    - recover-stalled-jobs.py
+    - recover-xml
+    - recover-xml-db
 
 - name: Remove obsolete lowercase PyWPS monitoring cron entries
   ansible.builtin.cron:
@@ -268,7 +261,6 @@
       {{ conda_envs_dir }}/{{ item.name }}/bin/python
       {{ cron_script_dir }}/pywps-job-control.py
       --config /etc/pywps/{{ item.name }}.cfg monitor
-      --layer xml --layer database --layer polling
     cron_file: ansible_pywps
     disabled: >-
       {{ cron_disabled }}
@@ -288,7 +280,6 @@
       {{ conda_envs_dir }}/{{ item.name }}/bin/python
       {{ cron_script_dir }}/pywps-job-control.py
       --config /etc/pywps/{{ item.name }}.cfg recover
-      --layer xml --layer database --layer polling
     cron_file: ansible_pywps
     disabled: >-
       {{ (cron_disabled | bool)

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -65,7 +65,11 @@
       - wps_job_control_schedule | type_debug == 'dict'
       - wps_job_control_recovery_schedule | type_debug == 'dict'
       - wps_job_statistics_schedule | type_debug == 'dict'
+      - wps_job_control_long_running_minutes | float > 0
       - wps_job_control_stale_after_minutes | float > 0
+      - >-
+        (wps_job_control_long_running_minutes | float)
+        < (wps_job_control_stale_after_minutes | float)
       - wps_job_control_recovery_limit | int > 0
       - wps_job_incident_keep_days | int > 0
       - wps_job_incident_keep_minutes | int > 0
@@ -83,8 +87,9 @@
         or (wps_job_control_stale_after_minutes | float) < (wps_outputs_keep_minutes | float)
     fail_msg: >-
       The job-control schedule must be a cron-field mapping, age must be
-      positive and shorter than output retention for scheduled XML checks,
-      and recovery and incident-retention limits must be positive.
+      positive and shorter than output retention for scheduled XML checks.
+      The long-running warning must be positive and shorter than the stale
+      threshold, and recovery and incident-retention limits must be positive.
       Missing-status recovery also requires a positive polling window, poll
       count and recovery limit, and a minimum poll duration shorter than its
       polling window.

--- a/roles/pywps/tasks/cronjob.yml
+++ b/roles/pywps/tasks/cronjob.yml
@@ -62,25 +62,25 @@
 - name: Validate job-control settings
   ansible.builtin.assert:
     that:
-      - pywps_job_control_schedule | type_debug == 'dict'
-      - pywps_job_control_recovery_schedule | type_debug == 'dict'
-      - pywps_job_statistics_schedule | type_debug == 'dict'
-      - pywps_job_control_stale_after_minutes | float > 0
-      - pywps_job_control_recovery_limit | int > 0
-      - pywps_job_incident_keep_days | int > 0
-      - pywps_job_incident_keep_minutes | int > 0
-      - pywps_job_incident_archive_dir | length > 0
-      - pywps_missing_status_poll_window_minutes | float > 0
-      - pywps_missing_status_min_poll_count | int > 0
-      - pywps_missing_status_min_poll_duration_minutes | float >= 0
+      - wps_job_control_schedule | type_debug == 'dict'
+      - wps_job_control_recovery_schedule | type_debug == 'dict'
+      - wps_job_statistics_schedule | type_debug == 'dict'
+      - wps_job_control_stale_after_minutes | float > 0
+      - wps_job_control_recovery_limit | int > 0
+      - wps_job_incident_keep_days | int > 0
+      - wps_job_incident_keep_minutes | int > 0
+      - wps_job_incident_archive_dir | length > 0
+      - wps_missing_status_poll_window_minutes | float > 0
+      - wps_missing_status_min_poll_count | int > 0
+      - wps_missing_status_min_poll_duration_minutes | float >= 0
       - >-
-        (pywps_missing_status_min_poll_duration_minutes | float)
-        < (pywps_missing_status_poll_window_minutes | float)
-      - pywps_missing_status_recovery_limit | int > 0
+        (wps_missing_status_min_poll_duration_minutes | float)
+        < (wps_missing_status_poll_window_minutes | float)
+      - wps_missing_status_recovery_limit | int > 0
       - >-
         not (cron_enabled | bool)
-        or not (pywps_job_control_monitor_enabled | bool)
-        or (pywps_job_control_stale_after_minutes | float) < (wps_outputs_keep_minutes | float)
+        or not (wps_job_control_monitor_enabled | bool)
+        or (wps_job_control_stale_after_minutes | float) < (wps_outputs_keep_minutes | float)
     fail_msg: >-
       The job-control schedule must be a cron-field mapping, age must be
       positive and shorter than output retention for scheduled XML checks,
@@ -99,22 +99,22 @@
 
 - name: Create PyWPS job-incident archive base directory
   ansible.builtin.file:
-    path: "{{ pywps_job_incident_archive_dir }}"
+    path: "{{ wps_job_incident_archive_dir }}"
     state: directory
     owner: root
     group: root
     mode: "0750"
-  when: pywps_job_incident_archive_enabled | bool
+  when: wps_job_incident_archive_enabled | bool
 
 - name: Create per-service PyWPS job-incident archive directories
   ansible.builtin.file:
-    path: "{{ pywps_job_incident_archive_dir }}/{{ item.name }}"
+    path: "{{ wps_job_incident_archive_dir }}/{{ item.name }}"
     state: directory
     owner: root
     group: root
     mode: "0750"
   loop: "{{ wps_services }}"
-  when: pywps_job_incident_archive_enabled | bool
+  when: wps_job_incident_archive_enabled | bool
 
 - name: Clean up expired PyWPS job incidents
   ansible.builtin.cron:
@@ -123,13 +123,13 @@
     hour: "*"
     user: "{{ cron_user }}"
     job: >-
-      find {{ pywps_job_incident_archive_dir }} -mindepth 2 -maxdepth 2
+      find {{ wps_job_incident_archive_dir }} -mindepth 2 -maxdepth 2
       -ignore_readdir_race -type f -name "*.xml"
-      -mmin +{{ pywps_job_incident_keep_minutes }} -delete
+      -mmin +{{ wps_job_incident_keep_minutes }} -delete
     cron_file: ansible_pywps
     disabled: >-
       {{ (cron_disabled | bool)
-         or not (pywps_job_incident_archive_enabled | bool) }}
+         or not (wps_job_incident_archive_enabled | bool) }}
     state: present
 
 - name: Validate Slurm timeout and monitoring settings
@@ -138,7 +138,7 @@
       - slurm_job_timeout_minutes | int > 0
       - >-
         slurm_job_timeout_minutes | int
-        < pywps_job_control_stale_after_minutes | float
+        < wps_job_control_stale_after_minutes | float
       - slurm_job_monitor_schedule | type_debug == 'dict'
       - slurm_job_monitor_user | length > 0
       - slurm_job_monitor_long_running_minutes | int > 0
@@ -251,11 +251,11 @@
 - name: Schedule PyWPS job monitoring
   ansible.builtin.cron:
     name: "monitor stalled PyWPS jobs for {{ item.name }}"
-    minute: "{{ pywps_job_control_schedule.minute | default('*/5') }}"
-    hour: "{{ pywps_job_control_schedule.hour | default('*') }}"
-    day: "{{ pywps_job_control_schedule.day | default('*') }}"
-    month: "{{ pywps_job_control_schedule.month | default('*') }}"
-    weekday: "{{ pywps_job_control_schedule.weekday | default('*') }}"
+    minute: "{{ wps_job_control_schedule.minute | default('*/5') }}"
+    hour: "{{ wps_job_control_schedule.hour | default('*') }}"
+    day: "{{ wps_job_control_schedule.day | default('*') }}"
+    month: "{{ wps_job_control_schedule.month | default('*') }}"
+    weekday: "{{ wps_job_control_schedule.weekday | default('*') }}"
     user: root
     job: >-
       {{ conda_envs_dir }}/{{ item.name }}/bin/python
@@ -270,11 +270,11 @@
 - name: Schedule ordered PyWPS job recovery
   ansible.builtin.cron:
     name: "recover stalled PyWPS jobs for {{ item.name }}"
-    minute: "{{ pywps_job_control_recovery_schedule.minute | default('1-56/5') }}"
-    hour: "{{ pywps_job_control_recovery_schedule.hour | default('*') }}"
-    day: "{{ pywps_job_control_recovery_schedule.day | default('*') }}"
-    month: "{{ pywps_job_control_recovery_schedule.month | default('*') }}"
-    weekday: "{{ pywps_job_control_recovery_schedule.weekday | default('*') }}"
+    minute: "{{ wps_job_control_recovery_schedule.minute | default('1-56/5') }}"
+    hour: "{{ wps_job_control_recovery_schedule.hour | default('*') }}"
+    day: "{{ wps_job_control_recovery_schedule.day | default('*') }}"
+    month: "{{ wps_job_control_recovery_schedule.month | default('*') }}"
+    weekday: "{{ wps_job_control_recovery_schedule.weekday | default('*') }}"
     user: root
     job: >-
       {{ conda_envs_dir }}/{{ item.name }}/bin/python
@@ -283,7 +283,7 @@
     cron_file: ansible_pywps
     disabled: >-
       {{ (cron_disabled | bool)
-         or not (pywps_job_control_recovery_enabled | bool) }}
+         or not (wps_job_control_recovery_enabled | bool) }}
     state: present
   loop: "{{ wps_services }}"
 
@@ -306,11 +306,11 @@
 - name: Schedule hourly PyWPS job statistics
   ansible.builtin.cron:
     name: "record hourly PyWPS job statistics for {{ item.name }}"
-    minute: "{{ pywps_job_statistics_schedule.minute | default('4') }}"
-    hour: "{{ pywps_job_statistics_schedule.hour | default('*') }}"
-    day: "{{ pywps_job_statistics_schedule.day | default('*') }}"
-    month: "{{ pywps_job_statistics_schedule.month | default('*') }}"
-    weekday: "{{ pywps_job_statistics_schedule.weekday | default('*') }}"
+    minute: "{{ wps_job_statistics_schedule.minute | default('4') }}"
+    hour: "{{ wps_job_statistics_schedule.hour | default('*') }}"
+    day: "{{ wps_job_statistics_schedule.day | default('*') }}"
+    month: "{{ wps_job_statistics_schedule.month | default('*') }}"
+    weekday: "{{ wps_job_statistics_schedule.weekday | default('*') }}"
     user: root
     job: >-
       {{ conda_envs_dir }}/{{ item.name }}/bin/python
@@ -324,8 +324,8 @@
 - name: Validate PyWPS restart schedule
   ansible.builtin.assert:
     that:
-      - pywps_restart_schedule in ['hourly', 'daily']
-    fail_msg: pywps_restart_schedule must be hourly or daily.
+      - wps_restart_schedule in ['hourly', 'daily']
+    fail_msg: wps_restart_schedule must be hourly or daily.
 
 - name: Copy restart script
   ansible.builtin.template:
@@ -338,14 +338,14 @@
 - name: Schedule PyWPS service restarts
   ansible.builtin.cron:
     name: "restart pywps {{ item.name }}"
-    special_time: "{{ pywps_restart_schedule }}"
+    special_time: "{{ wps_restart_schedule }}"
     user: root
     job: >-
       {{ cron_script_dir }}/restart-pywps.sh {{ item.name }}
       > /var/log/pywps/restart-{{ item.name }}.log 2>&1
     cron_file: ansible_pywps
     disabled: >-
-      {{ (cron_disabled | bool) or not (pywps_restart_enabled | bool) }}
+      {{ (cron_disabled | bool) or not (wps_restart_enabled | bool) }}
     state: present
   loop: "{{ wps_services }}"
 

--- a/roles/pywps/tasks/logrotate.yml
+++ b/roles/pywps/tasks/logrotate.yml
@@ -2,11 +2,11 @@
 - name: Validate PyWPS log rotation settings
   ansible.builtin.assert:
     that:
-      - pywps_logrotate_rotations | int > 0
-      - pywps_logrotate_min_size is match('^[1-9][0-9]*[kMGT]?$')
+      - wps_logrotate_rotations | int > 0
+      - wps_logrotate_min_size is match('^[1-9][0-9]*[kMGT]?$')
     fail_msg: >-
-      pywps_logrotate_rotations must be positive and
-      pywps_logrotate_min_size must be a positive logrotate size such as 10M.
+      wps_logrotate_rotations must be positive and
+      wps_logrotate_min_size must be a positive logrotate size such as 10M.
 
 - name: Copy pywps logrotate config
   ansible.builtin.template:

--- a/roles/pywps/tasks/main.yml
+++ b/roles/pywps/tasks/main.yml
@@ -4,4 +4,4 @@
 
 - name: Include web service tasks
   include_tasks: webservice.yml
-  when: pywps_webservice_enabled
+  when: wps_webservice_enabled

--- a/roles/pywps/templates/job-control-helper.sh.j2
+++ b/roles/pywps/templates/job-control-helper.sh.j2
@@ -40,26 +40,15 @@ main() {
     case $command_name in
         monitor)
             mode=monitor
-            script_options=(
-                --layer xml --layer database --layer polling
-                --show-summaries
-            )
+            script_options=(--show-summaries)
             ;;
-        recover-xml)
+        recover)
             mode=recover
-            script_options=(--layer xml)
-            ;;
-        recover-polling)
-            mode=recover
-            script_options=(--layer polling)
-            ;;
-        recover-xml-db)
-            mode=recover
-            script_options=(--layer xml --layer database)
+            script_options=(--show-summaries)
             ;;
         statistics)
             mode=statistics
-            script_options=(--layer xml --layer database --show-summaries)
+            script_options=(--show-summaries)
             ;;
         *)
             fail "Unsupported command name: $command_name"

--- a/roles/pywps/templates/logrotate.j2
+++ b/roles/pywps/templates/logrotate.j2
@@ -3,9 +3,9 @@
 #
 
 /var/log/pywps/*.log {
-    rotate {{ pywps_logrotate_rotations }}
+    rotate {{ wps_logrotate_rotations }}
     daily
-    minsize {{ pywps_logrotate_min_size }}
+    minsize {{ wps_logrotate_min_size }}
     dateext
     copytruncate
     missingok

--- a/roles/pywps/templates/pywps.cfg.j2
+++ b/roles/pywps/templates/pywps.cfg.j2
@@ -54,24 +54,24 @@ http_log_path = {{ wps_http_log_dir | default('/var/log/nginx') }}
 
 [job_control]
 # Report stalled requests without changing them.
-monitor_enabled = {{ pywps_job_control_monitor_enabled | bool | lower }}
+monitor_enabled = {{ wps_job_control_monitor_enabled | bool | lower }}
 # Allow commands that recover stalled requests or status documents.
-recovery_enabled = {{ pywps_job_control_recovery_enabled | bool | lower }}
+recovery_enabled = {{ wps_job_control_recovery_enabled | bool | lower }}
 # Create failure XML for repeated Nginx 404 status polling.
-missing_status_recovery_enabled = {{ pywps_missing_status_recovery_enabled | bool | lower }}
+missing_status_recovery_enabled = {{ wps_missing_status_recovery_enabled | bool | lower }}
 # Write a complete hourly job statistics report.
-statistics_enabled = {{ pywps_job_statistics_enabled | bool | lower }}
-stale_after_minutes = {{ pywps_job_control_stale_after_minutes }}
-recovery_limit = {{ pywps_job_control_recovery_limit }}
-incident_archive_enabled = {{ pywps_job_incident_archive_enabled | bool | lower }}
-incident_archive_dir = {{ pywps_job_incident_archive_dir }}/{{ item.name }}
+statistics_enabled = {{ wps_job_statistics_enabled | bool | lower }}
+stale_after_minutes = {{ wps_job_control_stale_after_minutes }}
+recovery_limit = {{ wps_job_control_recovery_limit }}
+incident_archive_enabled = {{ wps_job_incident_archive_enabled | bool | lower }}
+incident_archive_dir = {{ wps_job_incident_archive_dir }}/{{ item.name }}
 lock_file = /run/lock/pywps-job-control-{{ item.name }}.lock
-access_log = {{ pywps_missing_status_access_log }}
-poll_window_minutes = {{ pywps_missing_status_poll_window_minutes }}
-min_poll_count = {{ pywps_missing_status_min_poll_count }}
-min_poll_duration_minutes = {{ pywps_missing_status_min_poll_duration_minutes }}
-missing_status_recovery_limit = {{ pywps_missing_status_recovery_limit }}
-missing_status_database_guard = {{ pywps_missing_status_database_guard | bool | lower }}
+access_log = {{ wps_missing_status_access_log }}
+poll_window_minutes = {{ wps_missing_status_poll_window_minutes }}
+min_poll_count = {{ wps_missing_status_min_poll_count }}
+min_poll_duration_minutes = {{ wps_missing_status_min_poll_duration_minutes }}
+missing_status_recovery_limit = {{ wps_missing_status_recovery_limit }}
+missing_status_database_guard = {{ wps_missing_status_database_guard | bool | lower }}
 
 {% if item.extra_config is defined %}
 {{ item.extra_config }}

--- a/roles/pywps/templates/pywps.cfg.j2
+++ b/roles/pywps/templates/pywps.cfg.j2
@@ -61,8 +61,6 @@ recovery_enabled = {{ pywps_job_control_recovery_enabled | bool | lower }}
 missing_status_recovery_enabled = {{ pywps_missing_status_recovery_enabled | bool | lower }}
 # Write a complete hourly job statistics report.
 statistics_enabled = {{ pywps_job_statistics_enabled | bool | lower }}
-# Layers used when a command does not specify --layer.
-layers = {{ pywps_job_control_layers | join(',') }}
 stale_after_minutes = {{ pywps_job_control_stale_after_minutes }}
 recovery_limit = {{ pywps_job_control_recovery_limit }}
 incident_archive_enabled = {{ pywps_job_incident_archive_enabled | bool | lower }}

--- a/roles/pywps/templates/pywps.cfg.j2
+++ b/roles/pywps/templates/pywps.cfg.j2
@@ -61,6 +61,7 @@ recovery_enabled = {{ wps_job_control_recovery_enabled | bool | lower }}
 missing_status_recovery_enabled = {{ wps_missing_status_recovery_enabled | bool | lower }}
 # Write a complete hourly job statistics report.
 statistics_enabled = {{ wps_job_statistics_enabled | bool | lower }}
+long_running_minutes = {{ wps_job_control_long_running_minutes }}
 stale_after_minutes = {{ wps_job_control_stale_after_minutes }}
 recovery_limit = {{ wps_job_control_recovery_limit }}
 incident_archive_enabled = {{ wps_job_incident_archive_enabled | bool | lower }}

--- a/roles/pywps/templates/restart-pywps.sh.j2
+++ b/roles/pywps/templates/restart-pywps.sh.j2
@@ -4,7 +4,7 @@ set -euo pipefail
 
 export PATH="/usr/local/bin:/usr/bin:/bin"
 cleanup_orphaned_processes={{ gunicorn_cleanup_orphaned_processes | bool | lower }}
-restart_enabled={{ pywps_restart_enabled | bool | lower }}
+restart_enabled={{ wps_restart_enabled | bool | lower }}
 
 log_info() {
     echo "[INFO] $*"

--- a/scripts/pywps-job-control.py
+++ b/scripts/pywps-job-control.py
@@ -13,7 +13,7 @@ import re
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterable
@@ -84,6 +84,8 @@ class LayerSummary:
     stalled: int = 0
     recovered: int = 0
     errors: int = 0
+    stalled_jobs: set[str] = field(default_factory=set)
+    status_counts: dict[str, int] | None = None
 
 
 class SummaryConsoleFilter(logging.Filter):
@@ -91,7 +93,16 @@ class SummaryConsoleFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         return record.levelno >= logging.WARNING or record.getMessage().startswith(
-            ("summary ", "status_summary ")
+            ("summary ", "status_summary ", "current_status ")
+        )
+
+
+class StatisticsFilter(logging.Filter):
+    """Keep one routine current-status line while retaining real errors."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno >= logging.WARNING or record.getMessage().startswith(
+            "current_status "
         )
 
 
@@ -403,6 +414,7 @@ def run_xml_layer(
                 )
                 continue
             summary.stalled += 1
+            summary.stalled_jobs.add(document.job_uuid)
             logger.info(
                 "layer=xml job=%s status=%s finding=stalled updated=%s",
                 document.job_uuid,
@@ -685,6 +697,7 @@ def run_polling_layer(
                 )
                 continue
             summary.stalled += 1
+            summary.stalled_jobs.add(candidate.job_uuid)
             logger.info(
                 "layer=polling job=%s decision=missing-status polls=%d "
                 "first_seen=%s last_seen=%s",
@@ -805,17 +818,19 @@ def run_database_layer(
                 .all(),
                 WPS_STATUS,
             )
-            logger.info(
-                "status_summary total=%d accepted=%d running=%d "
-                "successful=%d failed=%d dismissed=%d unmapped=%d",
-                status_counts["total"],
-                status_counts["accepted"],
-                status_counts["running"],
-                status_counts["successful"],
-                status_counts["failed"],
-                status_counts["dismissed"],
-                status_counts["unmapped"],
-            )
+            summary.status_counts = status_counts
+            if settings.mode != "statistics":
+                logger.info(
+                    "status_summary total=%d accepted=%d running=%d "
+                    "successful=%d failed=%d dismissed=%d unmapped=%d",
+                    status_counts["total"],
+                    status_counts["accepted"],
+                    status_counts["running"],
+                    status_counts["successful"],
+                    status_counts["failed"],
+                    status_counts["dismissed"],
+                    status_counts["unmapped"],
+                )
         query = session.query(dblog.ProcessInstance).filter(
             or_(
                 dblog.ProcessInstance.status.is_(None),
@@ -848,6 +863,7 @@ def run_database_layer(
                     )
                     continue
                 summary.stalled += 1
+                summary.stalled_jobs.add(str(record.uuid))
                 logger.info(
                     "layer=database job=%s status=%s finding=stalled updated=%s",
                     record.uuid,
@@ -1126,7 +1142,7 @@ def configure_logging(
         file_handler.addFilter(service_filter)
         file_handler.setLevel(logging.INFO)
         if statistics_only:
-            file_handler.addFilter(SummaryConsoleFilter())
+            file_handler.addFilter(StatisticsFilter())
         handlers.append(file_handler)
     logging.basicConfig(
         level=logging.INFO,
@@ -1186,6 +1202,8 @@ def execute_layers(
             logger.exception("layer=%s decision=error reason=%s", layer, error)
             summary = LayerSummary(layer, errors=1)
         summaries.append(summary)
+        if settings.mode == "statistics":
+            continue
         if summary.errors:
             log_summary = logger.error
         elif summary.stalled:
@@ -1204,6 +1222,36 @@ def execute_layers(
             settings.limit if settings.limit is not None else "none",
         )
     return summaries
+
+
+def log_current_status(
+    summaries: list[LayerSummary],
+    logger: logging.Logger,
+) -> None:
+    by_name = {summary.name: summary for summary in summaries}
+    xml = by_name.get("xml", LayerSummary("xml"))
+    database = by_name.get("database", LayerSummary("database"))
+    counts = database.status_counts or {}
+    stalled_jobs = set().union(
+        *(summary.stalled_jobs for summary in summaries)
+    )
+    logger.info(
+        "current_status total=%s accepted=%s running=%s successful=%s "
+        "failed=%s dismissed=%s unmapped=%s stalled=%d xml_stalled=%d "
+        "database_stalled=%d xml_documents=%d errors=%d",
+        counts.get("total", "unknown"),
+        counts.get("accepted", "unknown"),
+        counts.get("running", "unknown"),
+        counts.get("successful", "unknown"),
+        counts.get("failed", "unknown"),
+        counts.get("dismissed", "unknown"),
+        counts.get("unmapped", "unknown"),
+        len(stalled_jobs),
+        xml.stalled,
+        database.stalled,
+        xml.checked,
+        sum(summary.errors for summary in summaries),
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1232,6 +1280,8 @@ def main(argv: list[str] | None = None) -> int:
             lock.write(f"{os.getpid()}\n")
             lock.flush()
             summaries = execute_layers(settings, datetime.now(UTC), logger)
+            if settings.mode == "statistics":
+                log_current_status(summaries, logger)
             return 1 if any(summary.errors for summary in summaries) else 0
     except (OSError, ValueError) as error:
         logging.basicConfig(

--- a/scripts/pywps-job-control.py
+++ b/scripts/pywps-job-control.py
@@ -33,6 +33,11 @@ XML_JOB_STATUSES = {
     "ProcessFailed": "failed",
 }
 SUPPORTED_LAYERS = ("xml", "database", "polling")
+DEFAULT_LAYERS = {
+    "monitor": SUPPORTED_LAYERS,
+    "recover": SUPPORTED_LAYERS,
+    "statistics": ("xml", "database"),
+}
 UTC = timezone.utc
 JOB_CONTROL_SECTION = "job_control"
 ACCESS_LOG_RE = re.compile(
@@ -925,11 +930,6 @@ def parse_args(argv: list[str] | None = None) -> Settings:
         config.add_section(JOB_CONTROL_SECTION)
     control_config = config[JOB_CONTROL_SECTION]
 
-    configured_layers = [
-        layer.strip()
-        for layer in control_config.get("layers", "xml,database").split(",")
-        if layer.strip()
-    ]
     parser = argparse.ArgumentParser(
         description=__doc__,
         parents=[pre_parser],
@@ -1043,10 +1043,10 @@ def parse_args(argv: list[str] | None = None) -> Settings:
         "incident_archive_enabled", fallback=False
     )
     incident_archive_dir = optional_path(control_config.get("incident_archive_dir"))
-    layers = args.layer or configured_layers
+    layers = args.layer or DEFAULT_LAYERS[args.mode]
     invalid = sorted(set(layers) - set(SUPPORTED_LAYERS))
     if invalid:
-        parser.error(f"unsupported configured layers: {', '.join(invalid)}")
+        parser.error(f"unsupported layers: {', '.join(invalid)}")
     if not layers:
         parser.error("at least one layer must be configured")
     if args.stale_after_minutes <= 0:

--- a/scripts/pywps-job-control.py
+++ b/scripts/pywps-job-control.py
@@ -75,6 +75,7 @@ class Settings:
     incident_archive_dir: Path | None = None
     recovery_limit: int = 100
     missing_status_recovery_limit: int = 20
+    long_running_minutes: float = 10
 
 
 @dataclass
@@ -86,6 +87,8 @@ class LayerSummary:
     errors: int = 0
     stalled_jobs: set[str] = field(default_factory=set)
     status_counts: dict[str, int] | None = None
+    long_running: int = 0
+    long_running_jobs: set[str] = field(default_factory=set)
 
 
 class SummaryConsoleFilter(logging.Filter):
@@ -743,6 +746,24 @@ def database_last_update(record: object) -> datetime:
     return value.astimezone(UTC)
 
 
+def database_start_time(record: object) -> datetime | None:
+    value = getattr(record, "time_start", None)
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def is_database_job_long_running(
+    record: object,
+    now: datetime,
+    threshold: timedelta,
+) -> bool:
+    started = database_start_time(record)
+    return started is not None and is_stalled(started, now, threshold)
+
+
 def database_job_status(value: object, wps_status: object) -> str | None:
     """Map a PyWPS database status to the OGC API Processes vocabulary."""
     if value == getattr(wps_status, "ACCEPTED", object()):
@@ -799,6 +820,7 @@ def run_database_layer(
         ) from error
 
     threshold = timedelta(minutes=settings.stale_after_minutes)
+    long_running_threshold = timedelta(minutes=settings.long_running_minutes)
     database_url = configuration.get_config_value("logging", "database")
     engine = create_engine(database_url)
     if not inspect(engine).has_table(dblog.ProcessInstance.__tablename__):
@@ -840,13 +862,24 @@ def run_database_layer(
             )
         )
         cutoff = (now - threshold).astimezone(UTC).replace(tzinfo=None)
+        long_running_cutoff = (now - long_running_threshold).astimezone(UTC).replace(
+            tzinfo=None
+        )
         last_update = func.coalesce(
             dblog.ProcessInstance.time_end,
             dblog.ProcessInstance.time_start,
         )
-        query = query.filter(
-            or_(last_update.is_(None), last_update <= cutoff)
-        ).order_by(last_update, dblog.ProcessInstance.uuid)
+        stale_filter = or_(last_update.is_(None), last_update <= cutoff)
+        if settings.mode == "recover":
+            query = query.filter(stale_filter)
+        else:
+            query = query.filter(
+                or_(
+                    stale_filter,
+                    dblog.ProcessInstance.time_start <= long_running_cutoff,
+                )
+            )
+        query = query.order_by(last_update, dblog.ProcessInstance.uuid)
         if settings.limit is not None:
             query = query.limit(settings.limit)
         records = query.all()
@@ -854,6 +887,23 @@ def run_database_layer(
             summary.checked += 1
             try:
                 last_update = database_last_update(record)
+                started = database_start_time(record)
+                if (
+                    settings.mode != "recover"
+                    and is_database_job_long_running(
+                        record, now, long_running_threshold
+                    )
+                ):
+                    summary.long_running += 1
+                    summary.long_running_jobs.add(str(record.uuid))
+                    logger.info(
+                        "layer=database job=%s status=%s finding=long-running "
+                        "started=%s elapsed_minutes=%d",
+                        record.uuid,
+                        database_job_status(record.status, WPS_STATUS) or "unmapped",
+                        started.isoformat(),
+                        int((now - started).total_seconds() // 60),
+                    )
                 if not is_stalled(last_update, now, threshold):
                     logger.debug(
                         "layer=database job=%s status=%s finding=recent updated=%s",
@@ -981,6 +1031,12 @@ def parse_args(argv: list[str] | None = None) -> Settings:
         help="show complete database status counts; intended for manual monitoring",
     )
     parser.add_argument(
+        "--long-running-minutes",
+        type=float,
+        default=float(control_config.get("long_running_minutes", "10")),
+        help="warn about nonfinal database jobs running this many minutes",
+    )
+    parser.add_argument(
         "--stale-after-minutes",
         type=float,
         default=float(control_config.get("stale_after_minutes", "120")),
@@ -1067,6 +1123,10 @@ def parse_args(argv: list[str] | None = None) -> Settings:
         parser.error("at least one layer must be configured")
     if args.stale_after_minutes <= 0:
         parser.error("--stale-after-minutes must be greater than zero")
+    if args.long_running_minutes <= 0:
+        parser.error("--long-running-minutes must be greater than zero")
+    if args.long_running_minutes >= args.stale_after_minutes:
+        parser.error("--long-running-minutes must be shorter than --stale-after-minutes")
     if limit is not None and limit <= 0:
         parser.error("--limit must be greater than zero")
     if recovery_limit <= 0 or missing_status_recovery_limit <= 0:
@@ -1118,6 +1178,7 @@ def parse_args(argv: list[str] | None = None) -> Settings:
         incident_archive_dir=incident_archive_dir,
         recovery_limit=recovery_limit,
         missing_status_recovery_limit=missing_status_recovery_limit,
+        long_running_minutes=args.long_running_minutes,
     )
 
 
@@ -1206,16 +1267,17 @@ def execute_layers(
             continue
         if summary.errors:
             log_summary = logger.error
-        elif summary.stalled:
+        elif summary.stalled or summary.long_running:
             log_summary = logger.warning
         else:
             log_summary = logger.info
         log_summary(
-            "summary layer=%s checked=%d stalled=%d recovered=%d errors=%d "
-            "mode=%s limit=%s",
+            "summary layer=%s checked=%d stalled=%d long_running=%d "
+            "recovered=%d errors=%d mode=%s limit=%s",
             summary.name,
             summary.checked,
             summary.stalled,
+            summary.long_running,
             summary.recovered,
             summary.errors,
             settings.mode,
@@ -1235,10 +1297,13 @@ def log_current_status(
     stalled_jobs = set().union(
         *(summary.stalled_jobs for summary in summaries)
     )
+    long_running_jobs = set().union(
+        *(summary.long_running_jobs for summary in summaries)
+    )
     logger.info(
         "current_status total=%s accepted=%s running=%s successful=%s "
-        "failed=%s dismissed=%s unmapped=%s stalled=%d xml_stalled=%d "
-        "database_stalled=%d xml_documents=%d errors=%d",
+        "failed=%s dismissed=%s unmapped=%s long_running=%d stalled=%d "
+        "xml_stalled=%d database_stalled=%d xml_documents=%d errors=%d",
         counts.get("total", "unknown"),
         counts.get("accepted", "unknown"),
         counts.get("running", "unknown"),
@@ -1246,6 +1311,7 @@ def log_current_status(
         counts.get("failed", "unknown"),
         counts.get("dismissed", "unknown"),
         counts.get("unmapped", "unknown"),
+        len(long_running_jobs),
         len(stalled_jobs),
         xml.stalled,
         database.stalled,

--- a/tests/configuration.yml
+++ b/tests/configuration.yml
@@ -47,7 +47,11 @@
           - wps_job_control_schedule.minute == '*/5'
           - wps_job_control_recovery_schedule.minute == '1-56/5'
           - wps_job_control_schedule.hour == '*'
+          - wps_job_control_long_running_minutes | float == 10
           - wps_job_control_stale_after_minutes | float > 0
+          - >-
+            wps_job_control_long_running_minutes | float
+            < wps_job_control_stale_after_minutes | float
           - wps_job_control_recovery_limit | int == 100
           - wps_job_incident_archive_enabled
           - wps_job_incident_archive_dir == '/var/lib/pywps/job-incidents'
@@ -330,6 +334,7 @@
           - "'missing_status_recovery_enabled = false' in test_pywps_config"
           - "'statistics_enabled = true' in test_pywps_config"
           - "'layers =' not in test_pywps_config"
+          - "'long_running_minutes = 10' in test_pywps_config"
           - "'stale_after_minutes = 120' in test_pywps_config"
           - "'recovery_limit = 100' in test_pywps_config"
           - "'incident_archive_enabled = true' in test_pywps_config"

--- a/tests/configuration.yml
+++ b/tests/configuration.yml
@@ -58,7 +58,6 @@
             < wps_outputs_keep_minutes | float
           - pywps_job_control_monitor_enabled
           - not pywps_job_control_recovery_enabled
-          - pywps_job_control_layers == ['xml', 'database']
           - not pywps_missing_status_recovery_enabled
           - pywps_missing_status_poll_window_minutes == 60
           - pywps_missing_status_min_poll_count == 3
@@ -80,7 +79,7 @@
           - >-
             slurm_job_timeout_minutes | int
             < pywps_job_control_stale_after_minutes | float
-          - not slurm_job_monitor_enabled
+          - slurm_job_monitor_enabled
           - slurm_job_monitor_schedule.minute == '*/5'
           - slurm_job_monitor_user == 'wps'
           - slurm_job_monitor_long_running_minutes | int == 10
@@ -274,18 +273,13 @@
           - "'local app_dir=\"/usr/local/src/$app\"' in test_smoke_script"
           - "'exec \"$pytest\" -v -k smoke \"$smoke_tests\"' in test_smoke_script"
           - "'monitor)' in test_job_control_helper"
-          - "'recover-xml)' in test_job_control_helper"
-          - "'recover-polling)' in test_job_control_helper"
-          - "'recover-xml-db)' in test_job_control_helper"
+          - "'recover)' in test_job_control_helper"
           - "'mode=recover' in test_job_control_helper"
           - "'statistics)' in test_job_control_helper"
           - "'mode=statistics' in test_job_control_helper"
-          - "'--layer xml --layer database --layer polling' in test_job_control_helper"
+          - "'script_options=(--layer' not in test_job_control_helper"
           - "'--status-counts' not in test_job_control_helper"
-          - "'script_options=(--layer xml)' in test_job_control_helper"
-          - "'script_options=(--layer polling)' in test_job_control_helper"
-          - "'script_options=(--layer xml --layer database)' in test_job_control_helper"
-          - "'script_options=(--layer xml --layer database --show-summaries)' in test_job_control_helper"
+          - test_job_control_helper.count('script_options=(--show-summaries)') == 3
           - >-
             'exec "$python" "$job_control_script"'
             in test_job_control_helper
@@ -335,7 +329,7 @@
           - "'recovery_enabled = false' in test_pywps_config"
           - "'missing_status_recovery_enabled = false' in test_pywps_config"
           - "'statistics_enabled = true' in test_pywps_config"
-          - "'layers = xml,database' in test_pywps_config"
+          - "'layers =' not in test_pywps_config"
           - "'stale_after_minutes = 120' in test_pywps_config"
           - "'recovery_limit = 100' in test_pywps_config"
           - "'incident_archive_enabled = true' in test_pywps_config"

--- a/tests/configuration.yml
+++ b/tests/configuration.yml
@@ -35,35 +35,35 @@
           - >-
             (wps_temp_keep_minutes | int) ==
             ((wps_temp_keep_hours | int) * 60)
-          - pywps_restart_schedule in ['hourly', 'daily']
-          - pywps_logrotate_min_size == '10M'
-          - pywps_logrotate_rotations == 7
-          - pywps_job_control_schedule | type_debug == 'dict'
-          - pywps_job_control_recovery_schedule | type_debug == 'dict'
-          - pywps_job_statistics_schedule | type_debug == 'dict'
-          - pywps_job_statistics_schedule.minute == '4'
-          - pywps_job_statistics_schedule.hour == '*'
-          - pywps_job_statistics_enabled
-          - pywps_job_control_schedule.minute == '*/5'
-          - pywps_job_control_recovery_schedule.minute == '1-56/5'
-          - pywps_job_control_schedule.hour == '*'
-          - pywps_job_control_stale_after_minutes | float > 0
-          - pywps_job_control_recovery_limit | int == 100
-          - pywps_job_incident_archive_enabled
-          - pywps_job_incident_archive_dir == '/var/lib/pywps/job-incidents'
-          - pywps_job_incident_keep_days == 30
-          - pywps_job_incident_keep_minutes | int == 43200
+          - wps_restart_schedule in ['hourly', 'daily']
+          - wps_logrotate_min_size == '10M'
+          - wps_logrotate_rotations == 7
+          - wps_job_control_schedule | type_debug == 'dict'
+          - wps_job_control_recovery_schedule | type_debug == 'dict'
+          - wps_job_statistics_schedule | type_debug == 'dict'
+          - wps_job_statistics_schedule.minute == '4'
+          - wps_job_statistics_schedule.hour == '*'
+          - wps_job_statistics_enabled
+          - wps_job_control_schedule.minute == '*/5'
+          - wps_job_control_recovery_schedule.minute == '1-56/5'
+          - wps_job_control_schedule.hour == '*'
+          - wps_job_control_stale_after_minutes | float > 0
+          - wps_job_control_recovery_limit | int == 100
+          - wps_job_incident_archive_enabled
+          - wps_job_incident_archive_dir == '/var/lib/pywps/job-incidents'
+          - wps_job_incident_keep_days == 30
+          - wps_job_incident_keep_minutes | int == 43200
           - >-
-            pywps_job_control_stale_after_minutes | float
+            wps_job_control_stale_after_minutes | float
             < wps_outputs_keep_minutes | float
-          - pywps_job_control_monitor_enabled
-          - not pywps_job_control_recovery_enabled
-          - not pywps_missing_status_recovery_enabled
-          - pywps_missing_status_poll_window_minutes == 60
-          - pywps_missing_status_min_poll_count == 3
-          - pywps_missing_status_min_poll_duration_minutes == 15
-          - pywps_missing_status_recovery_limit == 20
-          - pywps_missing_status_database_guard
+          - wps_job_control_monitor_enabled
+          - not wps_job_control_recovery_enabled
+          - not wps_missing_status_recovery_enabled
+          - wps_missing_status_poll_window_minutes == 60
+          - wps_missing_status_min_poll_count == 3
+          - wps_missing_status_min_poll_duration_minutes == 15
+          - wps_missing_status_recovery_limit == 20
+          - wps_missing_status_database_guard
           - wps_conda_channel == 'conda-forge'
           - "'psycopg2=2.9.12' in wps_conda_packages"
           - "'drmaa=0.7.9' in wps_conda_packages"
@@ -78,7 +78,7 @@
           - slurm_partitions[0].MaxTime | int == 90
           - >-
             slurm_job_timeout_minutes | int
-            < pywps_job_control_stale_after_minutes | float
+            < wps_job_control_stale_after_minutes | float
           - slurm_job_monitor_enabled
           - slurm_job_monitor_schedule.minute == '*/5'
           - slurm_job_monitor_user == 'wps'

--- a/tests/test_job_control.py
+++ b/tests/test_job_control.py
@@ -770,12 +770,16 @@ class RecoverStalledJobsTests(unittest.TestCase):
         status_summary = MODULE.logging.LogRecord(
             "test", MODULE.logging.INFO, __file__, 1, "status_summary total=5", (), None
         )
+        current_status = MODULE.logging.LogRecord(
+            "test", MODULE.logging.INFO, __file__, 1, "current_status total=5", (), None
+        )
         self.assertTrue(handler.filter(summary))
         self.assertTrue(handler.filter(status_summary))
+        self.assertTrue(handler.filter(current_status))
         self.assertFalse(handler.filter(finding))
         self.assertTrue(handler.filter(warning))
 
-    def test_statistics_log_keeps_only_summaries_status_counts_and_warnings(self):
+    def test_statistics_log_keeps_only_current_status_and_warnings(self):
         log_file = self.root / "statistics.log"
         with mock.patch.object(MODULE.logging, "basicConfig") as basic_config:
             MODULE.configure_logging(log_file, statistics_only=True)
@@ -801,10 +805,73 @@ class RecoverStalledJobsTests(unittest.TestCase):
         status_summary = MODULE.logging.LogRecord(
             "test", MODULE.logging.INFO, __file__, 1, "status_summary total=5", (), None
         )
-        self.assertTrue(file_handler.filter(summary))
-        self.assertTrue(file_handler.filter(status_summary))
+        current_status = MODULE.logging.LogRecord(
+            "test", MODULE.logging.INFO, __file__, 1, "current_status total=5", (), None
+        )
+        warning = MODULE.logging.LogRecord(
+            "test", MODULE.logging.WARNING, __file__, 1, "warning", (), None
+        )
+        self.assertFalse(file_handler.filter(summary))
+        self.assertFalse(file_handler.filter(status_summary))
+        self.assertTrue(file_handler.filter(current_status))
         self.assertFalse(file_handler.filter(finding))
+        self.assertTrue(file_handler.filter(warning))
         file_handler.close()
+
+    def test_statistics_logs_one_current_status_line_with_unique_stalled_jobs(self):
+        settings = self.settings("statistics", ["xml", "database"])
+        logger = mock.Mock()
+        counts = {
+            "total": 58,
+            "accepted": 3,
+            "running": 12,
+            "successful": 11,
+            "failed": 13,
+            "dismissed": 0,
+            "unmapped": 19,
+        }
+        xml = MODULE.LayerSummary(
+            "xml",
+            checked=40,
+            stalled=2,
+            stalled_jobs={JOB_UUID, OTHER_JOB_UUID},
+        )
+        database = MODULE.LayerSummary(
+            "database",
+            checked=2,
+            stalled=2,
+            stalled_jobs={OTHER_JOB_UUID, THIRD_JOB_UUID},
+            status_counts=counts,
+        )
+
+        summaries = MODULE.execute_layers(
+            settings,
+            self.now,
+            logger,
+            runners={
+                "xml": lambda *_args: xml,
+                "database": lambda *_args: database,
+            },
+        )
+        MODULE.log_current_status(summaries, logger)
+
+        logger.info.assert_called_once_with(
+            "current_status total=%s accepted=%s running=%s successful=%s "
+            "failed=%s dismissed=%s unmapped=%s stalled=%d xml_stalled=%d "
+            "database_stalled=%d xml_documents=%d errors=%d",
+            58,
+            3,
+            12,
+            11,
+            13,
+            0,
+            19,
+            3,
+            2,
+            2,
+            40,
+            0,
+        )
 
     def test_database_status_summary_uses_ogc_api_processes_vocabulary(self):
         statuses = argparse.Namespace(

--- a/tests/test_job_control.py
+++ b/tests/test_job_control.py
@@ -495,6 +495,7 @@ class RecoverStalledJobsTests(unittest.TestCase):
             "recovery_enabled = true\n"
             "missing_status_recovery_enabled = true\n"
             "statistics_enabled = true\n"
+            "long_running_minutes = 10\n"
             "stale_after_minutes = 360\n"
             "recovery_limit = 100\n"
             "incident_archive_enabled = true\n"
@@ -510,6 +511,7 @@ class RecoverStalledJobsTests(unittest.TestCase):
         )
         settings = MODULE.parse_args(["--config", str(config), "monitor"])
         self.assertEqual(settings.layers, ["xml", "database", "polling"])
+        self.assertEqual(settings.long_running_minutes, 10)
         self.assertEqual(settings.stale_after_minutes, 360)
         self.assertIsNone(settings.limit)
         self.assertEqual(settings.output_dir, self.outputs)
@@ -699,6 +701,7 @@ class RecoverStalledJobsTests(unittest.TestCase):
         cases = (
             (MODULE.LayerSummary("xml", checked=2), "info"),
             (MODULE.LayerSummary("xml", checked=2, stalled=1), "warning"),
+            (MODULE.LayerSummary("database", checked=2, long_running=1), "warning"),
             (MODULE.LayerSummary("xml", checked=2, errors=1), "error"),
         )
         for summary, expected_method in cases:
@@ -711,11 +714,12 @@ class RecoverStalledJobsTests(unittest.TestCase):
                     runners={"xml": lambda *_args, result=summary: result},
                 )
                 getattr(logger, expected_method).assert_called_once_with(
-                    "summary layer=%s checked=%d stalled=%d recovered=%d "
-                    "errors=%d mode=%s limit=%s",
+                    "summary layer=%s checked=%d stalled=%d long_running=%d "
+                    "recovered=%d errors=%d mode=%s limit=%s",
                     summary.name,
                     summary.checked,
                     summary.stalled,
+                    summary.long_running,
                     summary.recovered,
                     summary.errors,
                     "monitor",
@@ -842,6 +846,8 @@ class RecoverStalledJobsTests(unittest.TestCase):
             stalled=2,
             stalled_jobs={OTHER_JOB_UUID, THIRD_JOB_UUID},
             status_counts=counts,
+            long_running=2,
+            long_running_jobs={JOB_UUID, OTHER_JOB_UUID},
         )
 
         summaries = MODULE.execute_layers(
@@ -857,8 +863,8 @@ class RecoverStalledJobsTests(unittest.TestCase):
 
         logger.info.assert_called_once_with(
             "current_status total=%s accepted=%s running=%s successful=%s "
-            "failed=%s dismissed=%s unmapped=%s stalled=%d xml_stalled=%d "
-            "database_stalled=%d xml_documents=%d errors=%d",
+            "failed=%s dismissed=%s unmapped=%s long_running=%d stalled=%d "
+            "xml_stalled=%d database_stalled=%d xml_documents=%d errors=%d",
             58,
             3,
             12,
@@ -866,6 +872,7 @@ class RecoverStalledJobsTests(unittest.TestCase):
             13,
             0,
             19,
+            2,
             3,
             2,
             2,
@@ -916,6 +923,26 @@ class RecoverStalledJobsTests(unittest.TestCase):
         )
         record.time_end = None
         self.assertEqual(MODULE.database_last_update(record), start.replace(tzinfo=UTC))
+        self.assertEqual(MODULE.database_start_time(record), start.replace(tzinfo=UTC))
+        record.time_start = None
+        self.assertIsNone(MODULE.database_start_time(record))
+
+    def test_database_long_running_uses_request_start_not_last_update(self):
+        record = argparse.Namespace(
+            time_start=self.now - timedelta(minutes=11),
+            time_end=self.now - timedelta(minutes=1),
+        )
+        self.assertTrue(
+            MODULE.is_database_job_long_running(
+                record, self.now, timedelta(minutes=10)
+            )
+        )
+        record.time_start = self.now - timedelta(minutes=9)
+        self.assertFalse(
+            MODULE.is_database_job_long_running(
+                record, self.now, timedelta(minutes=10)
+            )
+        )
 
     @unittest.skipUnless(importlib.util.find_spec("pywps"), "PyWPS is not installed")
     def test_database_guard_vetoes_recent_and_old_nonfinal_requests(self):

--- a/tests/test_job_control.py
+++ b/tests/test_job_control.py
@@ -495,7 +495,6 @@ class RecoverStalledJobsTests(unittest.TestCase):
             "recovery_enabled = true\n"
             "missing_status_recovery_enabled = true\n"
             "statistics_enabled = true\n"
-            "layers = xml, database\n"
             "stale_after_minutes = 360\n"
             "recovery_limit = 100\n"
             "incident_archive_enabled = true\n"
@@ -510,7 +509,7 @@ class RecoverStalledJobsTests(unittest.TestCase):
             encoding="utf-8",
         )
         settings = MODULE.parse_args(["--config", str(config), "monitor"])
-        self.assertEqual(settings.layers, ["xml", "database"])
+        self.assertEqual(settings.layers, ["xml", "database", "polling"])
         self.assertEqual(settings.stale_after_minutes, 360)
         self.assertIsNone(settings.limit)
         self.assertEqual(settings.output_dir, self.outputs)
@@ -547,6 +546,9 @@ class RecoverStalledJobsTests(unittest.TestCase):
         self.assertEqual(overridden.layers, ["xml"])
         self.assertEqual(overridden.stale_after_minutes, 720)
         self.assertIsNone(overridden.limit)
+
+        recovery = MODULE.parse_args(["--config", str(config), "recover"])
+        self.assertEqual(recovery.layers, ["xml", "database", "polling"])
 
         selected_layers = MODULE.parse_args([
             "--config",


### PR DESCRIPTION
This PR cleans up the recovery scripts and logging:
* log long running jobs
* use consistently wps_ prefix for parameters
* status log is only one line